### PR TITLE
Allow user to Create and Delete Layers

### DIFF
--- a/src/composition/state/compositionReducer.ts
+++ b/src/composition/state/compositionReducer.ts
@@ -282,19 +282,6 @@ export const compositionReducer = (
 			const layer = state.layers[layerId];
 			const comp = state.compositions[layer.compositionId];
 
-			console.log(state, {
-				...state,
-				compositions: {
-					...state.compositions,
-					[comp.id]: {
-						...comp,
-						layers: comp.layers.filter((id) => id !== layer.id),
-					},
-				},
-				layers: removeKeysFromMap(state.layers, [layer.id]),
-				properties: removeKeysFromMap(state.properties, layer.properties),
-			});
-
 			return {
 				...state,
 				compositions: {

--- a/src/composition/timeline/CompositionTimeline.tsx
+++ b/src/composition/timeline/CompositionTimeline.tsx
@@ -111,6 +111,8 @@ const CompositionTimelineComponent: React.FC<Props> = (props) => {
 				onMouseDown={separateLeftRightMouse({
 					left: (e) =>
 						compositionTimelineHandlers.onMouseDownOut(e, outRef, props.composition.id),
+					right: (e) =>
+						compositionTimelineHandlers.onRightClickOut(e, props.composition.id),
 				})}
 			>
 				<div className={s("header")} />

--- a/src/composition/timeline/CompositionTimelineLayer.style.ts
+++ b/src/composition/timeline/CompositionTimelineLayer.style.ts
@@ -6,7 +6,7 @@ export default ({ css }: StyleParams) => ({
 		display: flex;
 		padding-left: 24px;
 		background: ${cssVariables.dark700};
-		margin-bottom: 1px;
+		margin: 1px 0;
 		border-radius: 2px;
 	`,
 

--- a/src/composition/timeline/CompositionTimelineLayer.tsx
+++ b/src/composition/timeline/CompositionTimelineLayer.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useStylesheet } from "~/util/stylesheets";
+import { compileStylesheetLabelled } from "~/util/stylesheets";
 import { CompositionLayer } from "~/composition/compositionTypes";
 import styles from "~/composition/timeline/CompositionTimelineLayer.style";
 import { CompositionTimelineLayerProperty } from "~/composition/timeline/CompositionTimelineLayerProperty";
@@ -13,6 +13,8 @@ import { useComputeHistory } from "~/hook/useComputeHistory";
 import { useActionState } from "~/hook/useActionState";
 import { ComputeNodeContext } from "~/nodeEditor/graph/computeNode";
 
+const s = compileStylesheetLabelled(styles);
+
 interface OwnProps {
 	id: string;
 	compositionId: string;
@@ -25,7 +27,6 @@ interface StateProps {
 type Props = OwnProps & StateProps;
 
 const CompositionTimelineLayerComponent: React.FC<Props> = (props) => {
-	const s = useStylesheet(styles);
 	const { layer, graph } = props;
 
 	const properties = useComputeHistory((state) =>
@@ -51,7 +52,12 @@ const CompositionTimelineLayerComponent: React.FC<Props> = (props) => {
 
 	return (
 		<>
-			<div className={s("container")}>
+			<div
+				className={s("container")}
+				onMouseDown={separateLeftRightMouse({
+					right: (e) => compositionTimelineHandlers.onLayerRightClick(e, layer.id),
+				})}
+			>
 				<div
 					className={s("name", { active: props.isSelected })}
 					onMouseDown={separateLeftRightMouse({

--- a/src/composition/timeline/compositionTimelineHandlers.ts
+++ b/src/composition/timeline/compositionTimelineHandlers.ts
@@ -235,7 +235,7 @@ export const compositionTimelineHandlers = {
 
 			params.dispatch(
 				contextMenuActions.openContextMenu(
-					"Composition Timeline Context Menu",
+					"Composition Timeline",
 					[
 						{
 							label: "Add new layer",

--- a/src/composition/timeline/compositionTimelineHandlers.ts
+++ b/src/composition/timeline/compositionTimelineHandlers.ts
@@ -13,6 +13,7 @@ import { Composition } from "~/composition/compositionTypes";
 import { compositionActions } from "~/composition/state/compositionReducer";
 import { getActionState } from "~/state/stateUtils";
 import { timelineActions } from "~/timeline/timelineActions";
+import { contextMenuActions } from "~/contextMenu/contextMenuActions";
 
 const ZOOM_FAC = 0.25;
 
@@ -219,6 +220,79 @@ export const compositionTimelineHandlers = {
 			const { dispatch, submitAction } = params;
 			dispatch(compositionActions.clearCompositionSelection(compositionId));
 			submitAction("Clear selection");
+		});
+	},
+
+	onRightClickOut: (e: React.MouseEvent, compositionId: string) => {
+		const position = Vec2.fromEvent(e);
+
+		requestAction({ history: true }, (params) => {
+			const addRectLayer = () => {
+				params.dispatch(compositionActions.createRectLayer(compositionId));
+				params.dispatch(contextMenuActions.closeContextMenu());
+				params.submitAction("Add Rect Layer");
+			};
+
+			params.dispatch(
+				contextMenuActions.openContextMenu(
+					"Composition Timeline Context Menu",
+					[
+						{
+							label: "Add new layer",
+							options: [
+								{
+									label: "Rect",
+									onSelect: addRectLayer,
+								},
+							],
+						},
+					],
+					position,
+					params.cancelAction,
+				),
+			);
+		});
+	},
+
+	onLayerRightClick: (e: React.MouseEvent, layerId: string) => {
+		const position = Vec2.fromEvent(e);
+
+		requestAction({ history: true }, (params) => {
+			const removeLayer = () => {
+				const compositionState = getActionState().compositions;
+				const layer = compositionState.layers[layerId];
+				const properties = layer.properties.map((id) => compositionState.properties[id]);
+
+				// Remove all timelines referenced by properties of the deleted layer.
+				//
+				// In the future, timelines may be referenced in more ways than just by animated
+				// properties. When that is the case we will have to check for other references to
+				// the timelines we're deleting.
+				const timelineIdsToRemove = properties
+					.filter((p) => p.timelineId)
+					.map((p) => p.timelineId);
+				for (let i = 0; i < timelineIdsToRemove.length; i += 1) {
+					params.dispatch(timelineActions.removeTimeline(timelineIdsToRemove[i]));
+				}
+
+				params.dispatch(compositionActions.removeLayer(layer.id));
+				params.dispatch(contextMenuActions.closeContextMenu());
+				params.submitAction("Delete layer");
+			};
+
+			params.dispatch(
+				contextMenuActions.openContextMenu(
+					"Layer",
+					[
+						{
+							label: "Delete",
+							onSelect: removeLayer,
+						},
+					],
+					position,
+					params.cancelAction,
+				),
+			);
 		});
 	},
 

--- a/src/composition/util/layerPropertyUtils.ts
+++ b/src/composition/util/layerPropertyUtils.ts
@@ -1,0 +1,62 @@
+import { CompositionLayerProperty } from "~/composition/compositionTypes";
+import { ValueType } from "~/types";
+import { TimelineColors } from "~/constants";
+
+interface Options {
+	createId: () => string;
+	compositionId: string;
+	layerId: string;
+}
+
+export const getDefaultLayerProperties = (opts: Options): CompositionLayerProperty[] => {
+	const { compositionId, createId, layerId } = opts;
+
+	return [
+		{
+			id: createId(),
+			layerId,
+			compositionId,
+			name: "x",
+			timelineId: "",
+			label: "X Position",
+			type: ValueType.Number,
+			value: 0,
+			color: TimelineColors.XPosition,
+		},
+		{
+			id: createId(),
+			layerId,
+			compositionId,
+			name: "y",
+			timelineId: "",
+			label: "Y Position",
+			type: ValueType.Number,
+			value: 0,
+			color: TimelineColors.YPosition,
+		},
+		{
+			id: createId(),
+			layerId,
+			compositionId,
+			name: "width",
+			timelineId: "",
+			label: "Width",
+			type: ValueType.Number,
+			color: TimelineColors.Width,
+			value: 100,
+			min: 0,
+		},
+		{
+			id: createId(),
+			layerId,
+			compositionId,
+			name: "height",
+			timelineId: "",
+			label: "Height",
+			type: ValueType.Number,
+			color: TimelineColors.Height,
+			value: 100,
+			min: 0,
+		},
+	];
+};

--- a/src/composition/workspace/CompositionWorkspaceViewport.tsx
+++ b/src/composition/workspace/CompositionWorkspaceViewport.tsx
@@ -1,8 +1,8 @@
 import React from "react";
-import { useActionState } from "~/hook/useActionState";
 import { compileStylesheetLabelled, StyleParams } from "~/util/stylesheets";
 import { cssVariables } from "~/cssVariables";
 import { CompositionWorkspaceLayer } from "~/composition/workspace/CompositionWorkspaceLayer";
+import { connectActionState } from "~/state/stateUtils";
 
 const styles = ({ css }: StyleParams) => ({
 	container: css`
@@ -13,22 +13,21 @@ const styles = ({ css }: StyleParams) => ({
 
 const s = compileStylesheetLabelled(styles);
 
-interface Props {
+interface OwnProps {
 	compositionId: string;
 }
+interface StateProps {
+	width: number;
+	height: number;
+	layerIds: string[];
+}
+type Props = OwnProps & StateProps;
 
-export const CompositionWorkspaceViewport: React.FC<Props> = (props) => {
-	const composition = useActionState(
-		(state) => state.compositions.compositions[props.compositionId],
-	);
-
-	const layerIds = composition.layers;
+const CompositionWorkspaceViewportComponent: React.FC<Props> = (props) => {
+	const { width, height, layerIds } = props;
 
 	return (
-		<div
-			className={s("container")}
-			style={{ width: composition.width, height: composition.height }}
-		>
+		<div className={s("container")} style={{ width, height }}>
 			{layerIds.map((id) => (
 				<CompositionWorkspaceLayer
 					key={id}
@@ -39,3 +38,16 @@ export const CompositionWorkspaceViewport: React.FC<Props> = (props) => {
 		</div>
 	);
 };
+
+const mapState: MapActionState<StateProps, OwnProps> = ({ compositions }, { compositionId }) => {
+	const { width, height, layers } = compositions.compositions[compositionId];
+	return {
+		width,
+		height,
+		layerIds: layers,
+	};
+};
+
+export const CompositionWorkspaceViewport = connectActionState(mapState)(
+	CompositionWorkspaceViewportComponent,
+);

--- a/src/nodeEditor/graph/computeLayerGraph.ts
+++ b/src/nodeEditor/graph/computeLayerGraph.ts
@@ -17,7 +17,7 @@ export const computeLayerGraph = (
 	const computeRawPropertyValues = (
 		context: ComputeNodeContext,
 	): { [propertyId: string]: number } => {
-		return properties.reduce<{
+		return context.properties.reduce<{
 			[propertyId: string]: number;
 		}>((obj, p) => {
 			obj[p.id] = p.timelineId

--- a/src/timeline/renderTimeline.ts
+++ b/src/timeline/renderTimeline.ts
@@ -46,14 +46,12 @@ export const createToTimelineViewportY = (options: {
 }): ((value: number) => number) => {
 	const { timelines, height } = options;
 
-	const paths: Array<CubicBezier | Line> = [];
+	const timelinePaths = timelines.map((timeline) =>
+		timelineKeyframesToPathList(timeline.keyframes),
+	);
 
-	for (let i = 0; i < timelines.length; i += 1) {
-		const keyframes = timelines[i].keyframes;
-		paths.push(...timelineKeyframesToPathList(keyframes));
-	}
-
-	const [yUpper, yLower] = timelines[0]._yBounds || getTimelineYBoundsFromPaths(timelines, paths);
+	const [yUpper, yLower] =
+		timelines[0]._yBounds || getTimelineYBoundsFromPaths(timelines, timelinePaths);
 	const yUpLowDiff = yUpper - yLower;
 
 	return (value: number) => {
@@ -80,11 +78,10 @@ export const renderTimeline = (options: RenderTimelineOptions) => {
 
 	const { _yBounds, _yPan } = timelines[0];
 
-	const allPaths = timelines.reduce<Array<CubicBezier | Line>>((arr, timeline) => {
-		arr.push(...timelineKeyframesToPathList(timeline.keyframes));
-		return arr;
-	}, []);
-	const [yUpper, yLower] = _yBounds || getTimelineYBoundsFromPaths(timelines, allPaths);
+	const timelinePathLists = timelines.map((timeline) =>
+		timelineKeyframesToPathList(timeline.keyframes),
+	);
+	const [yUpper, yLower] = _yBounds || getTimelineYBoundsFromPaths(timelines, timelinePathLists);
 
 	/**
 	 * Ticks

--- a/src/timeline/renderTimeline.ts
+++ b/src/timeline/renderTimeline.ts
@@ -78,10 +78,10 @@ export const renderTimeline = (options: RenderTimelineOptions) => {
 
 	const { _yBounds, _yPan } = timelines[0];
 
-	const timelinePathLists = timelines.map((timeline) =>
+	const timelinePaths = timelines.map((timeline) =>
 		timelineKeyframesToPathList(timeline.keyframes),
 	);
-	const [yUpper, yLower] = _yBounds || getTimelineYBoundsFromPaths(timelines, timelinePathLists);
+	const [yUpper, yLower] = _yBounds || getTimelineYBoundsFromPaths(timelines, timelinePaths);
 
 	/**
 	 * Ticks

--- a/src/timeline/timelineHandlers.ts
+++ b/src/timeline/timelineHandlers.ts
@@ -108,11 +108,10 @@ const actions = {
 			dispatch(timelineActions.toggleKeyframeSelection(timeline.id, keyframe.id));
 		}
 
-		const paths = timelines.reduce<Array<CubicBezier | Line>>((arr, timeline) => {
-			arr.push(...timelineKeyframesToPathList(timeline.keyframes));
-			return arr;
-		}, []);
-		const yBounds = getTimelineYBoundsFromPaths(timelines, paths);
+		const timelinePaths = timelines.map((timeline) =>
+			timelineKeyframesToPathList(timeline.keyframes),
+		);
+		const yBounds = getTimelineYBoundsFromPaths(timelines, timelinePaths);
 
 		let yPan = 0;
 		let hasMoved = false;
@@ -299,11 +298,10 @@ const actions = {
 		const dist = k1.index - k0.index;
 		const kDiff = k1.value - k0.value || 0.0001;
 
-		const paths = timelines.reduce<Array<CubicBezier | Line>>((arr, timeline) => {
-			arr.push(...timelineKeyframesToPathList(timeline.keyframes));
-			return arr;
-		}, []);
-		const yBounds = getTimelineYBoundsFromPaths(timelines, paths);
+		const timelinePaths = timelines.map((timeline) =>
+			timelineKeyframesToPathList(timeline.keyframes),
+		);
+		const yBounds = getTimelineYBoundsFromPaths(timelines, timelinePaths);
 
 		// Set bounds for all timelines
 		timelines.forEach(({ id }) => {

--- a/src/util/mapUtils.ts
+++ b/src/util/mapUtils.ts
@@ -1,0 +1,23 @@
+export const removeKeysFromMap = <T extends { [key: string]: any }>(obj: T, keys: string[]): T => {
+	return (Object.keys(obj) as Array<keyof T>).reduce<T>((newObj, key) => {
+		if (keys.indexOf(key) === -1) {
+			newObj[key] = obj[key];
+		}
+		return newObj;
+	}, {} as T);
+};
+
+export const addListToMap = <M extends { [key: string]: T }, T, I extends keyof T>(
+	map: M,
+	items: T[],
+	idField: I,
+): M => {
+	return {
+		...map,
+		...items.reduce<M>((obj, item) => {
+			const id = item[idField];
+			(obj as any)[id] = item;
+			return obj;
+		}, {} as M),
+	};
+};

--- a/src/util/mapUtils.ts
+++ b/src/util/mapUtils.ts
@@ -7,10 +7,10 @@ export const removeKeysFromMap = <T extends { [key: string]: any }>(obj: T, keys
 	}, {} as T);
 };
 
-export const addListToMap = <M extends { [key: string]: T }, T, I extends keyof T>(
+export const addListToMap = <M extends { [key: string]: T }, T>(
 	map: M,
 	items: T[],
-	idField: I,
+	idField: keyof T,
 ): M => {
 	return {
 		...map,


### PR DESCRIPTION
# Changes

## Add Layer

When you right click the empty space in `CompositionTimeline` a context menu is opened.

The only option is currently "Add new layer" with a single sub-option of "Rect".

![image](https://user-images.githubusercontent.com/20321920/83461711-edaf7e00-a458-11ea-8675-b790203ca98d.png)

When selected, a layer is created in the composition.


## Delete Layer

When a layer is right clicked (not the properties, they will have their own context menu), a context menu is opened.

![image](https://user-images.githubusercontent.com/20321920/83462210-213ed800-a45a-11ea-99e9-c2a250762ffc.png)

When clicked, the layer is deleted. All properties with a `timelineId` have their timelines removed.


## Fix bug in `getTimelineYBoundsFromPaths`

If two timelines were selected and both timelines had a single keyframe, only the y value from the first timeline would be considered.

To simplify the implementation `getTimelineYBoundsFromPaths`, we now replace all empty paths with a `[[x, y], [x + 1, y]]` line for the fn to work with. This avoids us having to check for empty path lists.


## Add utils for adding and removing items from a key value map

A common operation in this project is adding a list of `T` to a key value map

```tsx
{
  [key: string]: T;
}
```

Created the util fn `addListToMap`.

```tsx
export const addListToMap = <M extends { [key: string]: T }, T>(map: M, items: T[], idField: keyof T): M;
```

Another common operation is removing certain keys from a map. Created `remove`

```tsx
export const removeKeysFromMap = <T extends { [key: string]: any }>(obj: T, keys: string[]): T;
```

It alleviates writing and verbosely typing reduce statements in reducers that use key value maps.