### PR TITLE
Move timeline control points together

### DIFF
--- a/src/state/stateUtils.ts
+++ b/src/state/stateUtils.ts
@@ -90,3 +90,5 @@ export const getAreaActionState = <T>(areaId: string): T => {
 };
 
 export const getActionId = () => store.getState().area.action?.id || null;
+
+(window as any).getActionState = () => getActionState();

--- a/src/timeline/timelineActions.ts
+++ b/src/timeline/timelineActions.ts
@@ -30,6 +30,21 @@ export const timelineActions = {
 			resolve({ timelineId, indexShift, valueShift });
 	}),
 
+	setControlPointShift: createAction("timeline/SET_CP_SHIFT", (resolve) => {
+		return (timelineId: string, controlPointShift: Timeline["_controlPointShift"]) =>
+			resolve({ timelineId, controlPointShift });
+	}),
+
+	setNewControlPointShift: createAction("timeline/SET_NEW_CP_SHIFT", (resolve) => {
+		return (timelineId: string, newControlPointShift: Timeline["_newControlPointShift"]) =>
+			resolve({ timelineId, newControlPointShift });
+	}),
+
+	applyControlPointShift: createAction("timeline/APPLY_CP_SHIFT", (resolve) => {
+		return (timelineId: string, selection: TimelineSelection | undefined) =>
+			resolve({ timelineId, selection });
+	}),
+
 	submitIndexAndValueShift: createAction("timeline/SUBMIT_SHIFT", (resolve) => {
 		return (timelineId: string, selection: TimelineSelection) =>
 			resolve({ timelineId, selection });

--- a/src/timeline/timelineReducer.ts
+++ b/src/timeline/timelineReducer.ts
@@ -75,6 +75,8 @@ export const initialTimelineState: TimelineState = {
 		_indexShift: null,
 		_valueShift: null,
 		_dragSelectRect: null,
+		_controlPointShift: null,
+		_newControlPointShift: null,
 	},
 };
 
@@ -160,6 +162,36 @@ export function timelineReducer(state: TimelineState, action: Action): TimelineS
 					_indexShift: indexShift,
 					_valueShift: valueShift,
 				},
+			};
+		}
+
+		case getType(timelineActions.setControlPointShift): {
+			const { timelineId, controlPointShift } = action.payload;
+			return {
+				...state,
+				[timelineId]: {
+					...state[timelineId],
+					_controlPointShift: controlPointShift,
+				},
+			};
+		}
+
+		case getType(timelineActions.setNewControlPointShift): {
+			const { timelineId, newControlPointShift } = action.payload;
+			return {
+				...state,
+				[timelineId]: {
+					...state[timelineId],
+					_newControlPointShift: newControlPointShift,
+				},
+			};
+		}
+
+		case getType(timelineActions.applyControlPointShift): {
+			const { timelineId, selection } = action.payload;
+			return {
+				...state,
+				[timelineId]: applyTimelineIndexAndValueShifts(state[timelineId], selection),
 			};
 		}
 

--- a/src/timeline/timelineTypes.ts
+++ b/src/timeline/timelineTypes.ts
@@ -5,6 +5,19 @@ export interface Timeline {
 	_yPan: number;
 	_indexShift: number | null;
 	_valueShift: number | null;
+	_controlPointShift: null | {
+		indexDiff: number;
+		indexShift: number;
+		valueShift: number;
+		direction: "left" | "right";
+		yFac: number;
+	};
+	_newControlPointShift: null | {
+		indexShift: number;
+		valueShift: number;
+		keyframeIndex: number;
+		direction: "left" | "right";
+	};
 	_dragSelectRect: Rect | null;
 }
 

--- a/src/timeline/timelineUtils.ts
+++ b/src/timeline/timelineUtils.ts
@@ -247,15 +247,8 @@ export const transformGlobalToTimelinePosition = (
 	return pos;
 };
 
-const _applyNewControlPointShift = (
-	_timeline: Timeline,
-	selection: TimelineSelection | undefined,
-): Timeline => {
+const _applyNewControlPointShift = (_timeline: Timeline): Timeline => {
 	let timeline = _timeline;
-
-	if (!selection) {
-		return timeline;
-	}
 
 	const _newControlPointShift = timeline._newControlPointShift!;
 
@@ -299,15 +292,8 @@ const _applyNewControlPointShift = (
 	};
 };
 
-const _applyControlPointShift = (
-	_timeline: Timeline,
-	selection: TimelineSelection | undefined,
-): Timeline => {
+const _applyControlPointShift = (_timeline: Timeline, selection: TimelineSelection): Timeline => {
 	let timeline = _timeline;
-
-	if (!selection) {
-		return timeline;
-	}
 
 	const _controlPointShift = timeline._controlPointShift!;
 
@@ -449,6 +435,21 @@ export const applyTimelineIndexAndValueShifts = (
 	let timeline = _timeline;
 
 	if (!selection) {
+		if (
+			timeline._indexShift ||
+			timeline._valueShift ||
+			timeline._controlPointShift ||
+			timeline._newControlPointShift
+		) {
+			return {
+				...timeline,
+				_indexShift: null,
+				_valueShift: null,
+				_controlPointShift: null,
+				_newControlPointShift: null,
+			};
+		}
+
 		return timeline;
 	}
 
@@ -459,7 +460,7 @@ export const applyTimelineIndexAndValueShifts = (
 	}
 
 	if (_newControlPointShift) {
-		return _applyNewControlPointShift(_timeline, selection);
+		return _applyNewControlPointShift(_timeline);
 	}
 
 	if (typeof _indexShift !== "number" || typeof _valueShift !== "number") {

--- a/src/timeline/timelineUtils.ts
+++ b/src/timeline/timelineUtils.ts
@@ -332,10 +332,9 @@ const _applyControlPointShift = (
 			const indexDiff = timeline.keyframes[i0].index - timeline.keyframes[i1].index;
 			const indexShift = parentIndexShift * (parentIndexDiff / indexDiff);
 			return {
-				...cp,
 				relativeToDistance: indexDiff,
 				tx: capToRange(0, 1, cp.tx + indexShift / parentIndexDiff),
-				value: cp.value + valueShift,
+				value: cp.value * (indexDiff / cp.relativeToDistance) + valueShift,
 			};
 		};
 

--- a/src/util/math/vec2.ts
+++ b/src/util/math/vec2.ts
@@ -61,8 +61,11 @@ export class Vec2 {
 		return new Vec2(this.x, this.y - y);
 	}
 
-	public scale(scale: number): Vec2 {
-		return new Vec2(this.x * scale, this.y * scale);
+	public scale(scale: number, anchor = Vec2.new(0, 0)): Vec2 {
+		return new Vec2(
+			anchor.x + (this.x - anchor.x) * scale,
+			anchor.y + (this.y - anchor.y) * scale,
+		);
 	}
 
 	public scaleX(scale: number): Vec2 {
@@ -123,7 +126,7 @@ declare global {
 		public sub(vec: Vec2): Vec2;
 		public subX(x: number): Vec2;
 		public subY(y: number): Vec2;
-		public scale(scale: number): Vec2;
+		public scale(scale: number, anchor?: Vec2): Vec2;
 		public scaleX(scale: number): Vec2;
 		public scaleY(scale: number): Vec2;
 		public copy(): Vec2;


### PR DESCRIPTION
# Changes

## Move control points via shifts

Previously, we directly set the control points instead of setting "shifts". This is difficult to work with when moving from directly modifying a single object to n objects.

When I refer to shifts, I refer to the values that the control points will be shifted by when `mouseup` fires.

There are two relevant shifts we need to consider:

* Index shift (x)
* Value shift (y)


## Add `_controlPointShift` to `Timeline`

The `_controlPointShift` is the amount that the control points of **selected** keyframes should be moved by. The cp shift is defined like so.

```tsx
export interface Timeline {
        // ...
	_controlPointShift: null | {
		indexDiff: number;
		indexShift: number;
		valueShift: number;
		direction: "left" | "right";
		yFac: number;
	};
}
```

The `indexDiff` is the distance between `k0.index` and `k1.index`. This value is required because the `tx` of control points is a relative value.

The `indexShift` is how much the `tx` of a control point within `indexDiff` would move.

The `valueShift` is non-relative and describes how much the `value` of control points changes.

The `direction` describes whether a left or right control point of a keyframe is being moved. The control points of selected keyframes in that direction will be affected.

The `yFac` describes the current scale between index and value in the **current viewport**. It is used when reflecting the angle of the control point in the opposing direction.

When the angle, the length the user perceives the control point handle to be depends on the current viewport. In the image below, we are moving the left control point to be more flat along the y axis:

Before:
![image](https://user-images.githubusercontent.com/20321920/84575777-5ecb2b80-ad9f-11ea-89ae-c2db0ded1dea.png)

After: 
![image](https://user-images.githubusercontent.com/20321920/84575798-7efaea80-ad9f-11ea-86a3-3370553438a5.png)

But if the user were to zoom in and then make the same operation, the result would be way different:

Before:
![image](https://user-images.githubusercontent.com/20321920/84575812-99cd5f00-ad9f-11ea-826b-0aa47e2c59ea.png)

After:
![image](https://user-images.githubusercontent.com/20321920/84575819-a651b780-ad9f-11ea-910c-a4227f3e91f7.png)

We compute the `yFac` like so:

```tsx
const yFac = (toViewportX(1) - toViewportX(0)) / (toViewportY(1) - toViewportY(0));
```


## Add `_newControlPointShift` to `Timeline`

This is to describe the alt click and drag on keyframes to create new control points in each direction. In this action, the angle as well as the length of the control point is reflected.

It looks like so:

```tsx
export interface Timeline {
	// ...
	_newControlPointShift: null | {
		indexShift: number;
		valueShift: number;
		keyframeIndex: number;
		direction: "left" | "right";
	};
}
```

The `indexShift` and `valueShift` relative to the difference between `k0.index` and `k1.index` if the direction is `left`, and relative to `k1.index` and `k2.index` if the direction is `right`.

This makes computing `cpl` and `cpr` straightforward.

```tsx
const k0 = timeline.keyframes[i - 1];
const k1 = timeline.keyframes[i];
const k2 = timeline.keyframes[i + 1];

const fac = direction === "left" ? 1 : -1;
const cap = (t: number) => capToRange(0, 1, t);

const controlPointLeft = k0
	? {
		value: valueShift * fac,
		tx: cap((k1.index + indexShift * fac - k0.index) / (k1.index - k0.index)),
		relativeToDistance: k1.index - k0.index,
	  }
	: null;

const controlPointRight = k2
	? {
		value: -(valueShift * fac),
		tx: cap(1 - (k2.index + indexShift * fac - k1.index) / (k2.index - k1.index)),
		relativeToDistance: k2.index - k1.index,
	  }
	: null;

return { ...k, controlPointLeft, controlPointRight };
```

Note: When a keyframe is alt clicked and dragged, we clear the selection aside from the clicked keyframe. This does not change the operation we are doing since the `_newControlPointShift` is only set for the target timeline and keyframe, but I feel that it will make the UI cleaner during the operation when we introduce the "bounding rect" around selected keyframes in timelines.


## Why add these fields to `Timeline` instead of the area state?

Because the timelines are referenced outside of the area they are being modified in, typically by `CompositionWorkspace`.

We want changes to be reflected immediately to the user while the user is modifying the control points, so other areas need to be able to receive the shifts in real time. Area state does not make that easy, so adding these values to the individual timelines makes more sense.


## Add `anchor` argument to `Vec2.scale`

You can now scale a `Vec2` around an anchor point (`(0, 0)` by default).

```tsx
export class Vec2 {
	// ...

	scale(scale: number, anchor = Vec2.new(0, 0)): Vec2 {
		return new Vec2(
			anchor.x + (this.x - anchor.x) * scale,
			anchor.y + (this.y - anchor.y) * scale,
		);
	}
}
```
