### PR TITLE
Timeline Shift Move

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -100,3 +100,6 @@ export const CONTEXT_MENU_OPTION_HEIGHT = 22;
 
 export const DEG_TO_RAD_FAC = 0.0174533;
 export const RAD_TO_DEG_FAC = 57.2958;
+
+export const TIMELINE_CP_TX_MIN = 0.0001;
+export const TIMELINE_CP_TX_MAX = 1 - TIMELINE_CP_TX_MIN;

--- a/src/timeline/timelineTypes.ts
+++ b/src/timeline/timelineTypes.ts
@@ -11,6 +11,7 @@ export interface Timeline {
 		valueShift: number;
 		direction: "left" | "right";
 		yFac: number;
+		shiftDown: boolean;
 	};
 	_newControlPointShift: null | {
 		indexShift: number;

--- a/src/timeline/timelineUtils.ts
+++ b/src/timeline/timelineUtils.ts
@@ -37,6 +37,7 @@ import { TimelineSelection } from "~/timeline/timelineSelectionReducer";
 import { getActionState } from "~/state/stateUtils";
 import { splitCubicBezier } from "~/util/math/splitCubicBezier";
 import { intersectCubicBezierLine } from "~/util/math/intersection/intersectBezier3Line";
+import { TIMELINE_CP_TX_MIN, TIMELINE_CP_TX_MAX } from "~/constants";
 
 const getPathFromKeyframes = (k0: TimelineKeyframe, k1: TimelineKeyframe): CubicBezier | Line => {
 	if (k0.controlPointRight && k1.controlPointLeft) {
@@ -303,6 +304,7 @@ const _applyControlPointShift = (_timeline: Timeline, selection: TimelineSelecti
 		indexDiff: parentIndexDiff,
 		direction: direction,
 		yFac,
+		shiftDown,
 	} = _controlPointShift;
 
 	const keyframes = timeline.keyframes.map<TimelineKeyframe>((k, i) => {
@@ -319,8 +321,12 @@ const _applyControlPointShift = (_timeline: Timeline, selection: TimelineSelecti
 			const indexShift = parentIndexShift * (parentIndexDiff / indexDiff);
 			return {
 				relativeToDistance: indexDiff,
-				tx: capToRange(0, 1, cp.tx + indexShift / parentIndexDiff),
-				value: cp.value * (indexDiff / cp.relativeToDistance) + valueShift,
+				tx: capToRange(
+					TIMELINE_CP_TX_MIN,
+					TIMELINE_CP_TX_MAX,
+					cp.tx + indexShift / parentIndexDiff,
+				),
+				value: shiftDown ? 0 : cp.value * (indexDiff / cp.relativeToDistance) + valueShift,
 			};
 		};
 
@@ -359,7 +365,11 @@ const _applyControlPointShift = (_timeline: Timeline, selection: TimelineSelecti
 
 				cpr = {
 					relativeToDistance: k2.index - k1.index,
-					tx: capToRange(0, 1, (cprPosNew.x - k1.index) / (k2.index - k1.index)),
+					tx: capToRange(
+						TIMELINE_CP_TX_MIN,
+						TIMELINE_CP_TX_MAX,
+						(cprPosNew.x - k1.index) / (k2.index - k1.index),
+					),
 					value: cprPosNew.y - k1.value,
 				};
 			} else {
@@ -406,7 +416,11 @@ const _applyControlPointShift = (_timeline: Timeline, selection: TimelineSelecti
 
 				cpl = {
 					relativeToDistance: k1.index - k0.index,
-					tx: capToRange(0, 1, (cplPosNew.x - k0.index) / (k1.index - k0.index)),
+					tx: capToRange(
+						TIMELINE_CP_TX_MIN,
+						TIMELINE_CP_TX_MAX,
+						(cplPosNew.x - k0.index) / (k1.index - k0.index),
+					),
 					value: cplPosNew.y - k1.value,
 				};
 			} else {


### PR DESCRIPTION
Closes #14 

# Changes

## Shift move keyframes

When shift moving keyframes, we lock to the more significant axis according to the current viewport. To consider the viewport, we multiply `x` by the `yFac` which is computed like so.

```tsx
// Used for Shift moving (lock to more significant axis)
let yFac: number;
{
	const renderOptions = {
		timelines,
		length: options.length,
		viewBounds: options.viewBounds,
		width: viewport.width,
		height: viewport.height,
	};
	const toViewportY = createToTimelineViewportY(renderOptions);
	const toViewportX = createToTimelineViewportX(renderOptions);

	yFac = (toViewportX(1) - toViewportX(0)) / (toViewportY(1) - toViewportY(0));
}
```

## Shift when creating keyframe control points

When alt dragging from a keyframe, holding the shift key sets the `value` of the created control points to `0`.


## Shift when moving control points

When moving control points, holding shift locks the `value` to 0.


## Safer min and max for `tx`

When moving control points, their `tx` is capped from `0` to `1`. This introduces problems when reflecting the other control point if both `tx` and `value` are 0. This occurs more commonly when shift moving, so `tx` is now capped from `TIMELINE_CP_TX_MIN` to `TIMELINE_CP_TX_MAX`.

```tsx
export const TIMELINE_CP_TX_MIN = 0.0001;
export const TIMELINE_CP_TX_MAX = 1 - TIMELINE_CP_TX_MIN;
```