### PR TITLE
Open in Area and Create/Delete Layer Graphs

### DIFF
--- a/__tests__/area/areaRowToMinSize.spec.ts
+++ b/__tests__/area/areaRowToMinSize.spec.ts
@@ -1,9 +1,9 @@
 import { computeAreaRowToMinSize } from "~/area/util/areaRowToMinSize";
-import { AreaState } from "~/area/state/areaReducer";
+import { AreaReducerState } from "~/area/state/areaReducer";
 
 describe("computeAreaRowToMinSize", () => {
 	it("works", () => {
-		const areaState: AreaState = {
+		const areaState: AreaReducerState = {
 			_id: 0,
 			layout: {
 				0: {
@@ -43,6 +43,7 @@ describe("computeAreaRowToMinSize", () => {
 			areas: {},
 			rootId: "0",
 			joinPreview: null,
+			areaToOpen: null,
 		};
 
 		const result = computeAreaRowToMinSize(areaState.rootId, areaState.layout);

--- a/__tests__/area/areaToViewport.spec.ts
+++ b/__tests__/area/areaToViewport.spec.ts
@@ -1,9 +1,9 @@
 import { computeAreaToViewport } from "~/area/util/areaToViewport";
-import { AreaState } from "~/area/state/areaReducer";
+import { AreaReducerState } from "~/area/state/areaReducer";
 
 describe("computeAreaToViewport", () => {
 	it("creates a valid viewport", () => {
-		const areaState: AreaState = {
+		const areaState: AreaReducerState = {
 			_id: 0,
 			layout: {
 				0: {
@@ -43,6 +43,7 @@ describe("computeAreaToViewport", () => {
 			areas: {},
 			rootId: "0",
 			joinPreview: null,
+			areaToOpen: null,
 		};
 
 		const result = computeAreaToViewport(areaState.layout, areaState.rootId, {

--- a/src/area/areaRegistry.tsx
+++ b/src/area/areaRegistry.tsx
@@ -7,8 +7,11 @@ import { compositionTimelineAreaReducer } from "~/composition/timeline/compositi
 import { CompositionTimeline } from "~/composition/timeline/CompositionTimeline";
 import { CompositionWorkspace } from "~/composition/workspace/CompositionWorkspace";
 import { compositionWorkspaceAreaReducer } from "~/composition/workspace/compositionWorkspaceAreaReducer";
+import { AreaState, AreaComponentProps } from "~/types/areaTypes";
 
-export const areaComponentRegistry = {
+export const areaComponentRegistry: {
+	[T in AreaType]: React.ComponentType<AreaComponentProps<AreaState<T>>>;
+} = {
 	[AreaType.VectorEditor]: VectorEditor,
 	[AreaType.CompositionTimeline]: CompositionTimeline,
 	[AreaType.CompositionWorkspace]: CompositionWorkspace,
@@ -16,7 +19,9 @@ export const areaComponentRegistry = {
 	[AreaType.History]: HistoryEditor,
 };
 
-export const areaStateReducerRegistry = {
+export const areaStateReducerRegistry: {
+	[T in AreaType]: (state: AreaState<T>, action: any) => AreaState<T>;
+} = {
 	[AreaType.VectorEditor]: () => ({} as any),
 	[AreaType.CompositionTimeline]: compositionTimelineAreaReducer,
 	[AreaType.CompositionWorkspace]: compositionWorkspaceAreaReducer,

--- a/src/area/components/Area.tsx
+++ b/src/area/components/Area.tsx
@@ -3,8 +3,8 @@ import { connectActionState } from "~/state/stateUtils";
 import { handleAreaDragFromCorner } from "~/area/handlers/areaDragFromCorner";
 import { compileStylesheetLabelled } from "~/util/stylesheets";
 import styles from "~/area/components/Area.styles";
-import { AreaWindowProps } from "~/types/areaTypes";
-import { areaComponentRegistry } from "~/area/windows";
+import { AreaComponentProps } from "~/types/areaTypes";
+import { areaComponentRegistry } from "~/area/areaRegistry";
 import { AreaType, AREA_BORDER_WIDTH } from "~/constants";
 import { EditIcon } from "~/components/icons/EditIcon";
 import { PenIcon } from "~/components/icons/PenIcon";
@@ -22,7 +22,7 @@ interface StateProps {
 	state: any;
 	type: AreaType;
 	raised: boolean;
-	Component: React.ComponentType<AreaWindowProps<any>>;
+	Component: React.ComponentType<AreaComponentProps<any>>;
 }
 type Props = StateProps & OwnProps;
 
@@ -59,7 +59,7 @@ const typeToIndex = areaTypeOptions.reduce<{ [key: string]: number }>((obj, { ty
 	return obj;
 }, {});
 
-const AreaComponent: React.FC<Props> = (props) => {
+export const AreaComponent: React.FC<Props> = (props) => {
 	const { id, raised, viewport, Component, type } = props;
 
 	const { icon: Icon } = areaTypeOptions[typeToIndex[type]];
@@ -137,7 +137,7 @@ const mapStateToProps: MapActionState<StateProps, OwnProps> = (
 	const isBeingJoined = joinPreview && joinPreview.areaId === id;
 
 	const component = areaComponentRegistry[areas[id].type] as React.ComponentType<
-		AreaWindowProps<any>
+		AreaComponentProps<any>
 	>;
 
 	return {

--- a/src/area/components/AreaRoot.styles.ts
+++ b/src/area/components/AreaRoot.styles.ts
@@ -1,0 +1,47 @@
+import { StyleParams } from "~/util/stylesheets";
+import { cssZIndex, cssVariables } from "~/cssVariables";
+
+export default ({ css, keyframes }: StyleParams) => {
+	const areaToOpenContainerAnimation = keyframes`
+		0% { transform: scale(0.25); opacity: .3 }
+		50% { transform: scale(0.52); opacity: .8; }
+		100% { transform: scale(0.5); }
+	`;
+	return {
+		cursorCapture: css`
+			display: none;
+
+			&--active {
+				position: absolute;
+				display: block;
+				top: 0;
+				left: 0;
+				bottom: 0;
+				right: 0;
+				z-index: ${cssZIndex.area.cursorCapture};
+				cursor: not-allowed;
+			}
+		`,
+
+		areaToOpenContainer: css`
+			z-index: ${cssZIndex.area.areaToOpen};
+			transform: scale(0.5);
+			position: absolute;
+			opacity: 0.8;
+			animation: ${areaToOpenContainerAnimation} 0.3s;
+			cursor: grabbing;
+
+			& > * > * {
+				pointer-events: none;
+			}
+		`,
+
+		areaToOpenTargetOverlay: css`
+			z-index: ${cssZIndex.area.areaToOpenTarget};
+			position: absolute;
+			background: ${cssVariables.primary700};
+			border-radius: 8px;
+			opacity: 0.1;
+		`,
+	};
+};

--- a/src/area/components/AreaRoot.tsx
+++ b/src/area/components/AreaRoot.tsx
@@ -15,6 +15,7 @@ import { areaComponentRegistry } from "~/area/areaRegistry";
 import { getAreaToOpenTargetId } from "~/area/util/areaUtils";
 import { contractRect } from "~/util/math";
 import { AREA_BORDER_WIDTH } from "~/constants";
+import { useVec2TransitionState } from "~/hook/useNumberTransitionState";
 
 const s = compileStylesheet(({ css, keyframes }) => {
 	const areaToOpenContainerAnimation = keyframes`
@@ -116,6 +117,21 @@ const AreaRootComponent: React.FC<Props> = (props) => {
 		areaToOpen && getAreaToOpenTargetId(areaToOpen.position, areaState, areaToViewport);
 	const areaToOpenTargetViewport = areaToOpenTargetId && areaToViewport[areaToOpenTargetId];
 
+	const [areaToOpenDimensions, setAreaToOpenDimensions] = useVec2TransitionState(
+		Vec2.new(100, 100),
+		{ duration: 250, bezier: [0.24, 0.02, 0.18, 0.97] },
+	);
+
+	useEffect(() => {
+		if (!areaToOpenTargetId) {
+			return;
+		}
+
+		const viewport = areaToViewport[areaToOpenTargetId];
+
+		setAreaToOpenDimensions(Vec2.new(viewport.width, viewport.height));
+	}, [areaToOpenTargetId]);
+
 	return (
 		<div data-area-root>
 			{viewport && areaToOpen && (
@@ -133,10 +149,10 @@ const AreaRootComponent: React.FC<Props> = (props) => {
 						state={areaToOpen.area.state}
 						type={areaToOpen.area.type}
 						viewport={{
-							left: -250,
-							top: -175,
-							height: 350,
-							width: 500,
+							left: -(areaToOpenDimensions.x / 2),
+							top: -(areaToOpenDimensions.y / 2),
+							height: areaToOpenDimensions.y,
+							width: areaToOpenDimensions.x,
 						}}
 					/>
 				</div>

--- a/src/area/components/AreaRoot.tsx
+++ b/src/area/components/AreaRoot.tsx
@@ -1,43 +1,74 @@
 import "~/util/math/expressions";
 
 import React, { useState, useEffect, useRef } from "react";
-import { Area } from "~/area/components/Area";
+import { Area, AreaComponent } from "~/area/components/Area";
 import { connectActionState } from "~/state/stateUtils";
 import { computeAreaToViewport } from "~/area/util/areaToViewport";
-import { AreaState } from "~/area/state/areaReducer";
+import { AreaReducerState } from "~/area/state/areaReducer";
 import { JoinAreaPreview } from "~/area/components/JoinAreaPreview";
 import { compileStylesheet } from "~/util/stylesheets";
 import { AreaRowSeparators } from "~/area/components/AreaRowSeparators";
 
-import { cssZIndex } from "~/cssVariables";
+import { cssZIndex, cssVariables } from "~/cssVariables";
 import { getAreaRootViewport, _setAreaViewport } from "~/area/util/getAreaViewport";
+import { areaComponentRegistry } from "~/area/areaRegistry";
+import { getAreaToOpenTargetId } from "~/area/util/areaUtils";
+import { contractRect } from "~/util/math";
+import { AREA_BORDER_WIDTH } from "~/constants";
 
-const s = compileStylesheet(({ css }) => ({
-	cursorCapture: css`
-		display: none;
+const s = compileStylesheet(({ css, keyframes }) => {
+	const areaToOpenContainerAnimation = keyframes`
+		0% { transform: scale(0.25); opacity: .3 }
+		50% { transform: scale(0.52); opacity: .8; }
+		100% { transform: scale(0.5); }
+	`;
+	return {
+		cursorCapture: css`
+			display: none;
 
-		&--active {
+			&--active {
+				position: absolute;
+				display: block;
+				top: 0;
+				left: 0;
+				bottom: 0;
+				right: 0;
+				z-index: ${cssZIndex.area.cursorCapture};
+				cursor: not-allowed;
+			}
+		`,
+
+		areaToOpenContainer: css`
+			z-index: ${cssZIndex.area.areaToOpen};
+			transform: scale(0.5);
 			position: absolute;
-			display: block;
-			top: 0;
-			left: 0;
-			bottom: 0;
-			right: 0;
-			z-index: ${cssZIndex.area.cursorCapture};
-			cursor: not-allowed;
-		}
-	`,
-}));
+			opacity: 0.8;
+			animation: ${areaToOpenContainerAnimation} 0.3s;
+			cursor: grabbing;
+
+			& > * > * {
+				pointer-events: none;
+			}
+		`,
+
+		areaToOpenTargetOverlay: css`
+			z-index: ${cssZIndex.area.areaToOpenTarget};
+			position: absolute;
+			background: ${cssVariables.primary700};
+			border-radius: 8px;
+			opacity: 0.1;
+		`,
+	};
+});
 
 interface StateProps {
-	layout: AreaState["layout"];
-	rootId: string;
-	joinPreview: AreaState["joinPreview"];
+	areaState: AreaReducerState;
 }
 type Props = StateProps;
 
 const AreaRootComponent: React.FC<Props> = (props) => {
-	const { joinPreview } = props;
+	const { areaState } = props;
+	const { joinPreview, areaToOpen } = areaState;
 
 	const viewportMapRef = useRef<{ [areaId: string]: Rect }>({});
 
@@ -51,7 +82,7 @@ const AreaRootComponent: React.FC<Props> = (props) => {
 
 	{
 		const newMap =
-			(viewport && computeAreaToViewport(props.layout, props.rootId, viewport)) || {};
+			(viewport && computeAreaToViewport(areaState.layout, areaState.rootId, viewport)) || {};
 
 		const map = viewportMapRef.current;
 
@@ -81,11 +112,38 @@ const AreaRootComponent: React.FC<Props> = (props) => {
 	const areaToViewport = viewportMapRef.current;
 	_setAreaViewport(areaToViewport);
 
+	const areaToOpenTargetId =
+		areaToOpen && getAreaToOpenTargetId(areaToOpen.position, areaState, areaToViewport);
+	const areaToOpenTargetViewport = areaToOpenTargetId && areaToViewport[areaToOpenTargetId];
+
 	return (
 		<div data-area-root>
+			{viewport && areaToOpen && (
+				<div
+					className={s("areaToOpenContainer")}
+					style={{
+						left: areaToOpen.position.x,
+						top: areaToOpen.position.y,
+					}}
+				>
+					<AreaComponent
+						id="-1"
+						Component={areaComponentRegistry[areaToOpen.area.type]}
+						raised
+						state={areaToOpen.area.state}
+						type={areaToOpen.area.type}
+						viewport={{
+							left: -250,
+							top: -175,
+							height: 350,
+							width: 500,
+						}}
+					/>
+				</div>
+			)}
 			{viewport &&
-				Object.keys(props.layout).map((id) => {
-					const layout = props.layout[id];
+				Object.keys(areaState.layout).map((id) => {
+					const layout = areaState.layout[id];
 
 					if (layout.type === "area_row") {
 						return (
@@ -105,15 +163,19 @@ const AreaRootComponent: React.FC<Props> = (props) => {
 					movingInDirection={joinPreview.movingInDirection!}
 				/>
 			)}
+			{areaToOpenTargetViewport && (
+				<div
+					className={s("areaToOpenTargetOverlay")}
+					style={contractRect(areaToOpenTargetViewport, AREA_BORDER_WIDTH)}
+				/>
+			)}
 			<div className={s("cursorCapture", { active: !!joinPreview })} />
 		</div>
 	);
 };
 
 const mapStateToProps: MapActionState<StateProps> = ({ area }) => ({
-	joinPreview: area.joinPreview,
-	layout: area.layout,
-	rootId: area.rootId,
+	areaState: area,
 });
 
 export const AreaRoot = connectActionState(mapStateToProps)(AreaRootComponent);

--- a/src/area/components/AreaToOpenPreview.tsx
+++ b/src/area/components/AreaToOpenPreview.tsx
@@ -1,0 +1,86 @@
+import React from "react";
+import { connectActionState } from "~/state/stateUtils";
+import { contractRect } from "~/util/math";
+import { AreaReducerState } from "~/area/state/areaReducer";
+import { getAreaToOpenTargetId } from "~/area/util/areaUtils";
+import { useVec2TransitionState } from "~/hook/useNumberTransitionState";
+import { useEffect } from "react";
+import { AREA_BORDER_WIDTH } from "~/constants";
+import { AreaComponent } from "~/area/components/Area";
+import { areaComponentRegistry } from "~/area/areaRegistry";
+import { compileStylesheetLabelled } from "~/util/stylesheets";
+import AreaRootStyles from "~/area/components/AreaRoot.styles";
+
+const s = compileStylesheetLabelled(AreaRootStyles);
+
+interface OwnProps {
+	areaToViewport: { [key: string]: Rect };
+}
+interface StateProps {
+	areaState: AreaReducerState;
+}
+type Props = OwnProps & StateProps;
+
+const AreaToOpenPreviewComponent: React.FC<Props> = (props) => {
+	const { areaState } = props;
+	const { areaToOpen } = areaState;
+
+	const areaToOpenTargetId =
+		areaToOpen && getAreaToOpenTargetId(areaToOpen.position, areaState, props.areaToViewport);
+	const areaToOpenTargetViewport = areaToOpenTargetId && props.areaToViewport[areaToOpenTargetId];
+
+	const [areaToOpenDimensions, setAreaToOpenDimensions] = useVec2TransitionState(
+		Vec2.new(100, 100),
+		{ duration: 250, bezier: [0.24, 0.02, 0.18, 0.97] },
+	);
+
+	useEffect(() => {
+		if (!areaToOpenTargetId) {
+			return;
+		}
+
+		const viewport = props.areaToViewport[areaToOpenTargetId];
+
+		setAreaToOpenDimensions(Vec2.new(viewport.width, viewport.height));
+	}, [areaToOpenTargetId]);
+
+	if (!areaToOpen || !areaToOpenTargetViewport) {
+		return null;
+	}
+
+	return (
+		<>
+			<div
+				className={s("areaToOpenContainer")}
+				style={{
+					left: areaToOpen.position.x,
+					top: areaToOpen.position.y,
+				}}
+			>
+				<AreaComponent
+					id="-1"
+					Component={areaComponentRegistry[areaToOpen.area.type]}
+					raised
+					state={areaToOpen.area.state}
+					type={areaToOpen.area.type}
+					viewport={{
+						left: -(areaToOpenDimensions.x / 2),
+						top: -(areaToOpenDimensions.y / 2),
+						height: areaToOpenDimensions.y,
+						width: areaToOpenDimensions.x,
+					}}
+				/>
+			</div>
+			<div
+				className={s("areaToOpenTargetOverlay")}
+				style={contractRect(areaToOpenTargetViewport, AREA_BORDER_WIDTH)}
+			/>
+		</>
+	);
+};
+
+const mapStateToProps: MapActionState<StateProps> = ({ area }) => ({
+	areaState: area,
+});
+
+export const AreaToOpenPreview = connectActionState(mapStateToProps)(AreaToOpenPreviewComponent);

--- a/src/area/handlers/areaDragFromCorner.ts
+++ b/src/area/handlers/areaDragFromCorner.ts
@@ -6,7 +6,7 @@ import { areaActions } from "~/area/state/areaActions";
 import { CardinalDirection, IntercardinalDirection } from "~/types";
 import { isVecInRect, interpolate, capToRange } from "~/util/math";
 import { AreaRowLayout } from "~/types/areaTypes";
-import { AreaState } from "~/area/state/areaReducer";
+import { AreaReducerState } from "~/area/state/areaReducer";
 import { computeAreaToParentRow } from "~/area/util/areaToParentRow";
 import { computeAreaToViewport } from "~/area/util/areaToViewport";
 import { getAreaRootViewport } from "~/area/util/getAreaViewport";
@@ -25,7 +25,7 @@ const oppositeDirectionVectors = {
 	e: directionVectors.w,
 };
 
-const getEligibleAreaIndices = (areaState: AreaState, row: AreaRowLayout, index: number) => {
+const getEligibleAreaIndices = (areaState: AreaReducerState, row: AreaRowLayout, index: number) => {
 	return [index - 1, index + 1].filter((i) => {
 		if (i < 0 || i > row.areas.length - 1) {
 			return false;

--- a/src/area/state/areaActions.ts
+++ b/src/area/state/areaActions.ts
@@ -1,8 +1,14 @@
 import { createAction } from "typesafe-actions";
 import { CardinalDirection } from "~/types";
 import { AreaType } from "~/constants";
+import { AreaReducerState } from "~/area/state/areaReducer";
+import { AreaState } from "~/types/areaTypes";
 
 export const areaActions = {
+	setFields: createAction("area/SET_FIELDS", (action) => {
+		return (fields: Partial<AreaReducerState>) => action({ fields });
+	}),
+
 	setJoinAreasPreview: createAction("area/SET_JOIN_PREVIEW", (action) => {
 		return (areaId: string | null, from: CardinalDirection | null, eligibleAreaIds: string[]) =>
 			action({ areaId, from, eligibleAreaIds });
@@ -31,7 +37,8 @@ export const areaActions = {
 	}),
 
 	setAreaType: createAction("area/SET_TYPE", (action) => {
-		return (areaId: string, type: AreaType) => action({ areaId, type });
+		return <T extends AreaType>(areaId: string, type: T, initialState?: AreaState<T>) =>
+			action({ areaId, type, initialState });
 	}),
 
 	dispatchToAreaState: createAction("area/DISPATCH_TO_AREA_STATE", (_action) => {

--- a/src/area/state/areaInitialStates.ts
+++ b/src/area/state/areaInitialStates.ts
@@ -2,8 +2,9 @@ import { AreaType } from "~/constants";
 import { initialNodeEditorAreaState } from "~/nodeEditor/nodeEditorAreaReducer";
 import { initialCompositionTimelineAreaState } from "~/composition/timeline/compositionTimelineAreaReducer";
 import { initialCompositionWorkspaceAreaState } from "~/composition/workspace/compositionWorkspaceAreaReducer";
+import { AreaState } from "~/types/areaTypes";
 
-export const areaInitialStates: { [key in AreaType]: any } = {
+export const areaInitialStates: { [K in AreaType]: AreaState<K> } = {
 	[AreaType.VectorEditor]: {},
 	[AreaType.CompositionTimeline]: initialCompositionTimelineAreaState,
 	[AreaType.CompositionWorkspace]: initialCompositionWorkspaceAreaState,

--- a/src/area/util/areaRowToMinSize.ts
+++ b/src/area/util/areaRowToMinSize.ts
@@ -1,6 +1,6 @@
-import { AreaState } from "~/area/state/areaReducer";
+import { AreaReducerState } from "~/area/state/areaReducer";
 
-export const computeAreaRowToMinSize = (rootId: string, areaLayout: AreaState["layout"]) => {
+export const computeAreaRowToMinSize = (rootId: string, areaLayout: AreaReducerState["layout"]) => {
 	const rowToMinSize: { [areaId: string]: { width: number; height: number } } = {};
 
 	const root = areaLayout[rootId];

--- a/src/area/util/areaToParentRow.ts
+++ b/src/area/util/areaToParentRow.ts
@@ -1,6 +1,6 @@
-import { AreaState } from "~/area/state/areaReducer";
+import { AreaReducerState } from "~/area/state/areaReducer";
 
-export const computeAreaToParentRow = (areaState: AreaState) => {
+export const computeAreaToParentRow = (areaState: AreaReducerState) => {
 	const areaToParentRow: { [key: string]: string } = {};
 
 	const keys = Object.keys(areaState.layout);

--- a/src/area/util/areaToViewport.ts
+++ b/src/area/util/areaToViewport.ts
@@ -1,10 +1,10 @@
-import { AreaState } from "~/area/state/areaReducer";
+import { AreaReducerState } from "~/area/state/areaReducer";
 import { AreaLayout, AreaRowLayout } from "~/types/areaTypes";
 import { AREA_MIN_CONTENT_WIDTH } from "~/constants";
 import { computeAreaRowToMinSize } from "~/area/util/areaRowToMinSize";
 
 export const computeAreaToViewport = (
-	areaLayout: AreaState["layout"],
+	areaLayout: AreaReducerState["layout"],
 	rootId: string,
 	rootViewport: Rect,
 ) => {

--- a/src/area/util/areaUtils.ts
+++ b/src/area/util/areaUtils.ts
@@ -1,0 +1,27 @@
+import { AreaReducerState } from "~/area/state/areaReducer";
+import { isVecInRect } from "~/util/math";
+
+export const getAreaToOpenTargetId = (
+	position: Vec2,
+	areaState: AreaReducerState,
+	areaToViewport: {
+		[areaId: string]: Rect;
+	},
+): string | undefined => {
+	let areaId: string | undefined;
+
+	const keys = Object.keys(areaState.areas);
+	for (let i = 0; i < keys.length; i += 1) {
+		if (areaState.layout[keys[i]].type !== "area") {
+			continue;
+		}
+
+		const areaViewport = areaToViewport[keys[i]];
+		if (isVecInRect(position, areaViewport)) {
+			areaId = keys[i];
+			break;
+		}
+	}
+
+	return areaId;
+};

--- a/src/components/common/NumberInput.styles.ts
+++ b/src/components/common/NumberInput.styles.ts
@@ -6,6 +6,8 @@ export default ({ css }: StyleParams) => ({
 		cursor: pointer;
 		border: none;
 		height: 16px;
+		font-family: ${cssVariables.fontFamily};
+		font-size: 11px;
 		color: ${cssVariables.primary700};
 		background-color: transparent;
 		transition: background-color 0.3s;
@@ -64,10 +66,17 @@ export default ({ css }: StyleParams) => ({
 		outline: none;
 		background-color: ${cssVariables.dark300};
 		border: 1px solid ${cssVariables.primary400};
+		font-size: 11px;
 		padding: 0 3px;
-		line-height: 18px;
+		padding-top: 1px;
+		padding-bottom: 1px;
 		border-radius: 3px;
-		font-weight: 300;
+		font-weight: 400;
 		transform: translateY(-1px);
+
+		&::selection {
+			color: white;
+			background: ${cssVariables.primary700};
+		}
 	`,
 });

--- a/src/components/icons/OpenInAreaIcon.tsx
+++ b/src/components/icons/OpenInAreaIcon.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+
+export const OpenInAreaIcon: React.FC = () => (
+	<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+		<path
+			fillRule="evenodd"
+			clipRule="evenodd"
+			d="M4 6C2.89543 6 2 6.89543 2 8V12H4V8H10V6H4ZM22 6V8H28V12H30V8C30 6.89543 29.1046 6 28 6H22ZM10 24H4V20H2V24C2 25.1046 2.89543 26 4 26H10V24ZM22 26H28C29.1046 26 30 25.1046 30 24V20H28V24H22V26Z"
+		/>
+	</svg>
+);

--- a/src/composition/state/compositionReducer.ts
+++ b/src/composition/state/compositionReducer.ts
@@ -7,7 +7,7 @@ import {
 import { TimelineColors } from "~/constants";
 import { ValueType } from "~/types";
 import { getDefaultLayerProperties } from "~/composition/util/layerPropertyUtils";
-import { removeKeysFromMap, addListToMap } from "~/util/mapUtils";
+import { removeKeysFromMap, addListToMap, modifyItemInMap } from "~/util/mapUtils";
 
 const createLayerId = (layers: CompositionState["layers"]) =>
 	(
@@ -168,6 +168,10 @@ export const compositionActions = {
 	removeLayer: createAction("comp/DELETE_LAYER", (action) => {
 		return (layerId: string) => action({ layerId });
 	}),
+
+	setLayerGraphId: createAction("comp/SET_LAYER_GRAPH_ID", (action) => {
+		return (layerId: string, graphId: string) => action({ layerId, graphId });
+	}),
 };
 
 type Action = ActionType<typeof compositionActions>;
@@ -293,6 +297,17 @@ export const compositionReducer = (
 				},
 				layers: removeKeysFromMap(state.layers, [layer.id]),
 				properties: removeKeysFromMap(state.properties, layer.properties),
+			};
+		}
+
+		case getType(compositionActions.setLayerGraphId): {
+			const { layerId, graphId } = action.payload;
+			return {
+				...state,
+				layers: modifyItemInMap(state.layers, layerId, (layer) => ({
+					...layer,
+					graphId,
+				})),
 			};
 		}
 

--- a/src/composition/timeline/CompositionTimeline.tsx
+++ b/src/composition/timeline/CompositionTimeline.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef } from "react";
-import { AreaWindowProps } from "~/types/areaTypes";
+import { AreaComponentProps } from "~/types/areaTypes";
 import { compileStylesheetLabelled } from "~/util/stylesheets";
 import { connectActionState } from "~/state/stateUtils";
 import {
@@ -25,7 +25,7 @@ const s = compileStylesheetLabelled(styles);
 
 const SEPARATOR_WIDTH = 4;
 
-type OwnProps = AreaWindowProps<CompositionTimelineAreaState>;
+type OwnProps = AreaComponentProps<CompositionTimelineAreaState>;
 interface StateProps {
 	composition: Composition;
 	selection: CompositionSelectionState;

--- a/src/composition/timeline/CompositionTimelineLayer.style.ts
+++ b/src/composition/timeline/CompositionTimelineLayer.style.ts
@@ -46,8 +46,42 @@ export default ({ css }: StyleParams) => ({
 			left: 50%;
 			width: 14px;
 			height: 14px;
-			fill: ${cssVariables.primary500};
+			fill: ${cssVariables.light300};
 			transform: translate(-50%, -50%);
+		}
+
+		&--active {
+			svg {
+				fill: ${cssVariables.primary500};
+			}
+		}
+	`,
+
+	openGraphInArea: css`
+		margin-left: 2px;
+		height: 16px;
+		width: 16px;
+		position: relative;
+		cursor: grab;
+
+		&:active {
+			cursor: grabbing;
+		}
+
+		svg {
+			position: absolute;
+			top: 50%;
+			left: 50%;
+			width: 14px;
+			height: 14px;
+			fill: ${cssVariables.light300};
+			transform: translate(-50%, -50%);
+		}
+
+		&--active {
+			svg {
+				fill: ${cssVariables.primary500};
+			}
 		}
 	`,
 });

--- a/src/composition/timeline/CompositionTimelineLayer.tsx
+++ b/src/composition/timeline/CompositionTimelineLayer.tsx
@@ -12,6 +12,7 @@ import { computeLayerGraph } from "~/nodeEditor/graph/computeLayerGraph";
 import { useComputeHistory } from "~/hook/useComputeHistory";
 import { useActionState } from "~/hook/useActionState";
 import { ComputeNodeContext } from "~/nodeEditor/graph/computeNode";
+import { OpenInAreaIcon } from "~/components/icons/OpenInAreaIcon";
 
 const s = compileStylesheetLabelled(styles);
 
@@ -71,9 +72,27 @@ const CompositionTimelineLayerComponent: React.FC<Props> = (props) => {
 				>
 					{layer.name}
 				</div>
-				<div className={s("graph")}>
+				<div
+					title={layer.graphId ? "Delete Layer Graph" : "Create Layer Graph"}
+					className={s("graph", { active: !!layer.graphId })}
+					onMouseDown={separateLeftRightMouse({
+						left: (e) => compositionTimelineHandlers.onLayerGraphMouseDown(e, layer.id),
+					})}
+				>
 					<GraphIcon />
 				</div>
+				{!!layer.graphId && (
+					<div
+						title="Open Graph in area"
+						className={s("openGraphInArea", { active: true })}
+						onMouseDown={separateLeftRightMouse({
+							left: (e) =>
+								compositionTimelineHandlers.onOpenGraphInAreaMouseDown(e, layer.id),
+						})}
+					>
+						<OpenInAreaIcon />
+					</div>
+				)}
 			</div>
 			{layer.properties.map((propertyId, i) => {
 				return (

--- a/src/composition/workspace/CompositionWorkspace.tsx
+++ b/src/composition/workspace/CompositionWorkspace.tsx
@@ -1,5 +1,5 @@
 import React, { useRef } from "react";
-import { AreaWindowProps } from "~/types/areaTypes";
+import { AreaComponentProps } from "~/types/areaTypes";
 import { CompositionWorkspaceAreaState } from "~/composition/workspace/compositionWorkspaceAreaReducer";
 import { useKeyDownEffect } from "~/hook/useKeyDown";
 import { compileStylesheetLabelled } from "~/util/stylesheets";
@@ -14,7 +14,7 @@ import { useActionState } from "~/hook/useActionState";
 
 const s = compileStylesheetLabelled(styles);
 
-type Props = AreaWindowProps<CompositionWorkspaceAreaState>;
+type Props = AreaComponentProps<CompositionWorkspaceAreaState>;
 
 export const CompositionWorkspace: React.FC<Props> = (props) => {
 	const clickCaptureTarget = useRef<HTMLDivElement>(null);

--- a/src/composition/workspace/compositionWorkspaceHandlers.ts
+++ b/src/composition/workspace/compositionWorkspaceHandlers.ts
@@ -1,12 +1,8 @@
 import { RequestActionParams, requestAction } from "~/listener/requestAction";
 import { isKeyDown } from "~/listener/keyboard";
-import {
-	compositionWorkspaceAreaActions,
-	CompositionWorkspaceAreaState,
-} from "~/composition/workspace/compositionWorkspaceAreaReducer";
+import { compositionWorkspaceAreaActions } from "~/composition/workspace/compositionWorkspaceAreaReducer";
 import { areaActions } from "~/area/state/areaActions";
 import { getAreaActionState } from "~/state/stateUtils";
-import { NodeEditorAreaState } from "~/nodeEditor/nodeEditorAreaReducer";
 import { getAreaViewport } from "~/area/util/getAreaViewport";
 import { AreaType } from "~/constants";
 
@@ -52,7 +48,7 @@ export const compositionWorkspaceHandlers = {
 	onPanStart: (e: React.MouseEvent, areaId: string) => {
 		e.preventDefault();
 
-		const areaState = getAreaActionState<NodeEditorAreaState>(areaId);
+		const areaState = getAreaActionState<AreaType.NodeEditor>(areaId);
 		const initialPos = Vec2.fromEvent(e);
 
 		requestAction({}, ({ addListener, dispatch, submitAction }) => {
@@ -70,7 +66,7 @@ export const compositionWorkspaceHandlers = {
 	onZoomClick: (e: React.MouseEvent, areaId: string) => {
 		e.preventDefault();
 
-		const areaState = getAreaActionState<CompositionWorkspaceAreaState>(areaId);
+		const areaState = getAreaActionState<AreaType.CompositionWorkspace>(areaId);
 		const viewport = getAreaViewport(areaId, AreaType.CompositionWorkspace);
 
 		requestAction({}, (params) => {

--- a/src/contextMenu/ContextMenu.tsx
+++ b/src/contextMenu/ContextMenu.tsx
@@ -84,7 +84,6 @@ const ContextMenuComponent: React.FC<Props> = (props) => {
 		}
 
 		if (reduceStackRect && !isVecInRect(vec, reduceStackRect)) {
-			console.log("reduced");
 			setStack(stack.slice(0, stack.length - 1));
 			return;
 		}

--- a/src/cssVariables.ts
+++ b/src/cssVariables.ts
@@ -52,6 +52,8 @@ export const cssZIndex = {
 		cursorCapture: 15,
 		areaRaised: 20,
 		joinPreview: 25,
+		areaToOpenTarget: 99,
+		areaToOpen: 100,
 	},
 	toolbar: 100,
 	contextMenuBackground: 500,

--- a/src/hook/useNumberTransitionState.ts
+++ b/src/hook/useNumberTransitionState.ts
@@ -1,0 +1,65 @@
+import { useState, useRef } from "react";
+import { animate } from "~/util/animation/animate";
+
+export const useNumberTransitionState = (
+	initialValue: number,
+	options: { bezier?: [number, number, number, number]; duration?: number } = {},
+): [number, (value: number) => void] => {
+	const [value, _setValue] = useState(initialValue);
+
+	let activeAnimationRef = useRef<ReturnType<typeof animate> | null>(null);
+
+	const lastValRef = useRef(value);
+	lastValRef.current = value;
+
+	const setValue = (newValue: number) => {
+		if (activeAnimationRef.current) {
+			activeAnimationRef.current.cancel();
+		}
+
+		const promise = animate({ ...options, from: lastValRef.current, to: newValue }, (v) => {
+			_setValue(v);
+		});
+		promise.then((cancelled) => {
+			if (!cancelled) {
+				activeAnimationRef.current = null;
+			}
+		});
+
+		activeAnimationRef.current = promise;
+	};
+
+	return [value, setValue];
+};
+
+export const useVec2TransitionState = (
+	initialValue: Vec2,
+	options: { bezier?: [number, number, number, number]; duration?: number } = {},
+): [Vec2, (value: Vec2) => void] => {
+	const [value, _setValue] = useState(initialValue);
+
+	let activeAnimationRef = useRef<ReturnType<typeof animate> | null>(null);
+
+	const lastValRef = useRef(value);
+	lastValRef.current = value;
+
+	const setValue = (newValue: Vec2) => {
+		if (activeAnimationRef.current) {
+			activeAnimationRef.current.cancel();
+		}
+
+		const from = lastValRef.current;
+		const promise = animate({ ...options, from: 0, to: 1 }, (t) => {
+			_setValue(from.lerp(newValue, t));
+		});
+		promise.then((cancelled) => {
+			if (!cancelled) {
+				activeAnimationRef.current = null;
+			}
+		});
+
+		activeAnimationRef.current = promise;
+	};
+
+	return [value, setValue];
+};

--- a/src/nodeEditor/NodeEditor.tsx
+++ b/src/nodeEditor/NodeEditor.tsx
@@ -1,7 +1,7 @@
 import React, { useRef, useState, useEffect } from "react";
 import { connectActionState } from "~/state/stateUtils";
 import { compileStylesheetLabelled } from "~/util/stylesheets";
-import { AreaWindowProps } from "~/types/areaTypes";
+import { AreaComponentProps } from "~/types/areaTypes";
 import { NodeEditorAreaState } from "~/nodeEditor/nodeEditorAreaReducer";
 import { nodeEditorHandlers } from "~/nodeEditor/nodeEditorHandlers";
 import styles from "~/nodeEditor/NodeEditor.styles";
@@ -21,7 +21,7 @@ import { Vec2InputNode } from "~/nodeEditor/nodes/Vec2InputNode";
 
 const s = compileStylesheetLabelled(styles);
 
-type OwnProps = AreaWindowProps<NodeEditorAreaState>;
+type OwnProps = AreaComponentProps<NodeEditorAreaState>;
 interface StateProps {
 	graph: NodeEditorGraphState;
 }
@@ -52,7 +52,6 @@ const NodeEditorComponent: React.FC<Props> = (props) => {
 	});
 
 	const { graph } = props;
-	const nodeIds = Object.keys(graph.nodes);
 
 	const [clickCaptureFn, setClickCaptureFn] = useState<{
 		fn: ((e: React.MouseEvent) => void) | null;
@@ -62,7 +61,6 @@ const NodeEditorComponent: React.FC<Props> = (props) => {
 	useEffect(() => {
 		const el = clickCaptureTarget.current;
 		if (el) {
-			console.log(clickCaptureFn.fn ? "block" : "");
 			el.style.display = clickCaptureFn.fn ? "block" : "";
 		}
 
@@ -89,6 +87,12 @@ const NodeEditorComponent: React.FC<Props> = (props) => {
 
 		return () => {};
 	}, [clickCaptureFn.fn]);
+
+	if (!graph) {
+		return null;
+	}
+
+	const nodeIds = Object.keys(graph.nodes);
 
 	return (
 		<>

--- a/src/nodeEditor/dragSelect/NodeEditorDragSelect.tsx
+++ b/src/nodeEditor/dragSelect/NodeEditorDragSelect.tsx
@@ -2,11 +2,11 @@ import React from "react";
 import { compileStylesheetLabelled } from "~/util/stylesheets";
 import { cssZIndex } from "~/cssVariables";
 import { useRef } from "react";
-import { AreaWindowProps } from "~/types/areaTypes";
+import { AreaComponentProps } from "~/types/areaTypes";
 import { NodeEditorAreaState } from "~/nodeEditor/nodeEditorAreaReducer";
 import { connectActionState } from "~/state/stateUtils";
 
-type OwnProps = AreaWindowProps<NodeEditorAreaState>;
+type OwnProps = AreaComponentProps<NodeEditorAreaState>;
 interface StateProps {
 	rect: Rect | null;
 }

--- a/src/nodeEditor/graph/createLayerGraph.ts
+++ b/src/nodeEditor/graph/createLayerGraph.ts
@@ -1,0 +1,41 @@
+import uuid from "uuid/v4";
+import { NodeEditorGraphState } from "~/nodeEditor/nodeEditorReducers";
+import { NodeEditorNodeInput, getNodeEditorNodeDefaultState } from "~/nodeEditor/nodeEditorIO";
+import { NodeEditorNodeType } from "~/types";
+import { CompositionLayerProperty } from "~/composition/compositionTypes";
+import { DEFAULT_NODE_EDITOR_NODE_WIDTH } from "~/constants";
+
+export const createLayerGraph = (
+	layerId: string,
+	properties: CompositionLayerProperty[],
+): NodeEditorGraphState => {
+	const nodeId = "0";
+	return {
+		id: uuid(),
+		nodes: {
+			[nodeId]: {
+				id: nodeId,
+				position: Vec2.new(0, 0),
+				state: getNodeEditorNodeDefaultState(NodeEditorNodeType.layer_input),
+				type: NodeEditorNodeType.layer_input,
+				width: DEFAULT_NODE_EDITOR_NODE_WIDTH,
+				outputs: [],
+				inputs: properties.map<NodeEditorNodeInput>((property) => ({
+					name: property.name,
+					pointer: null,
+					type: property.type,
+					value: null,
+				})),
+			},
+		},
+		selection: {
+			nodes: {},
+		},
+		layerId,
+		moveVector: Vec2.new(0, 0),
+		_addNodeOfTypeOnClick: null,
+		_dragInputTo: null,
+		_dragOutputTo: null,
+		_dragSelectRect: null,
+	};
+};

--- a/src/nodeEditor/nodeEditorActions.ts
+++ b/src/nodeEditor/nodeEditorActions.ts
@@ -6,8 +6,19 @@ import {
 	NodeEditorNodeOutput,
 	NodeEditorNodeIO,
 } from "~/nodeEditor/nodeEditorIO";
+import { NodeEditorGraphState } from "~/nodeEditor/nodeEditorReducers";
 
 export const nodeEditorActions = {
+	/**
+	 * Graph
+	 */
+	setGraph: createAction("nodeEditorGraph/SET_GRAPH", (action) => {
+		return (graph: NodeEditorGraphState) => action({ graph });
+	}),
+	removeGraph: createAction("nodeEditorGraph/REMOVE_GRAPH", (action) => {
+		return (graphId: string) => action({ graphId });
+	}),
+
 	/**
 	 * Add node
 	 */

--- a/src/nodeEditor/nodeEditorAreaActions.ts
+++ b/src/nodeEditor/nodeEditorAreaActions.ts
@@ -1,11 +1,15 @@
 import { createAction } from "typesafe-actions";
 
 export const nodeEditorAreaActions = {
-	setPan: createAction("nodeEditorArea/SET_PAN", action => {
+	setGraphId: createAction("nodeEditorArea/SET_GRAPH_ID", (action) => {
+		return (graphId: string) => action({ graphId });
+	}),
+
+	setPan: createAction("nodeEditorArea/SET_PAN", (action) => {
 		return (pan: Vec2) => action({ pan });
 	}),
 
-	setScale: createAction("nodeEditorArea/SET_SCALE", action => {
+	setScale: createAction("nodeEditorArea/SET_SCALE", (action) => {
 		return (scale: number) => action({ scale });
 	}),
 };

--- a/src/nodeEditor/nodeEditorAreaReducer.ts
+++ b/src/nodeEditor/nodeEditorAreaReducer.ts
@@ -13,7 +13,7 @@ export interface NodeEditorAreaState {
 export const initialNodeEditorAreaState: NodeEditorAreaState = {
 	pan: Vec2.new(0, 0),
 	scale: 1,
-	graphId: "0",
+	graphId: "",
 };
 
 export const nodeEditorAreaReducer = (
@@ -21,6 +21,11 @@ export const nodeEditorAreaReducer = (
 	action: ToolAction,
 ): NodeEditorAreaState => {
 	switch (action.type) {
+		case getType(nodeEditorAreaActions.setGraphId): {
+			const { graphId } = action.payload;
+			return { ...state, graphId };
+		}
+
 		case getType(nodeEditorAreaActions.setPan): {
 			const { pan } = action.payload;
 			return { ...state, pan };

--- a/src/nodeEditor/nodeEditorHandlers.ts
+++ b/src/nodeEditor/nodeEditorHandlers.ts
@@ -2,7 +2,6 @@ import { areaActions } from "~/area/state/areaActions";
 import { requestAction } from "~/listener/requestAction";
 import { nodeEditorAreaActions } from "~/nodeEditor/nodeEditorAreaActions";
 import { getAreaActionState } from "~/state/stateUtils";
-import { NodeEditorAreaState } from "~/nodeEditor/nodeEditorAreaReducer";
 import { isKeyDown } from "~/listener/keyboard";
 import { isLeftClick } from "~/util/mouse";
 import { nodeEditorActions } from "~/nodeEditor/nodeEditorActions";
@@ -101,7 +100,7 @@ export const nodeEditorHandlers = {
 	onPanStart: (areaId: string, e: React.MouseEvent) => {
 		e.preventDefault();
 
-		const areaState = getAreaActionState<NodeEditorAreaState>(areaId);
+		const areaState = getAreaActionState<AreaType.NodeEditor>(areaId);
 		const initialPos = Vec2.fromEvent(e);
 
 		requestAction({}, ({ addListener, dispatch, submitAction }) => {
@@ -123,7 +122,7 @@ export const nodeEditorHandlers = {
 			return;
 		}
 
-		const areaState = getAreaActionState<NodeEditorAreaState>(areaId);
+		const areaState = getAreaActionState<AreaType.NodeEditor>(areaId);
 
 		if (
 			(areaState.scale < 0.0625 && isKeyDown("Alt")) ||

--- a/src/nodeEditor/nodeEditorReducers.ts
+++ b/src/nodeEditor/nodeEditorReducers.ts
@@ -12,6 +12,7 @@ import {
 } from "~/nodeEditor/nodeEditorIO";
 import { rectsIntersect } from "~/util/math";
 import { calculateNodeHeight } from "~/nodeEditor/util/calculateNodeHeight";
+import { removeKeysFromMap } from "~/util/mapUtils";
 
 type NodeEditorAction = ActionType<typeof actions>;
 
@@ -80,7 +81,31 @@ export const initialNodeEditorState: NodeEditorState = {
 	},
 };
 
-export function nodeEditorReducer(state: NodeEditorState, action: NodeEditorAction) {
+export function nodeEditorReducer(
+	state: NodeEditorState,
+	action: NodeEditorAction,
+): NodeEditorState {
+	switch (action.type) {
+		case getType(actions.setGraph): {
+			const { graph } = action.payload;
+			return {
+				...state,
+				graphs: {
+					...state.graphs,
+					[graph.id]: graph,
+				},
+			};
+		}
+
+		case getType(actions.removeGraph): {
+			const { graphId } = action.payload;
+			return {
+				...state,
+				graphs: removeKeysFromMap(state.graphs, [graphId]),
+			};
+		}
+	}
+
 	const graphId = action.payload.graphId;
 	const graph = state.graphs[graphId];
 	return {

--- a/src/nodeEditor/nodes/expression/expressionNodeHandlers.ts
+++ b/src/nodeEditor/nodes/expression/expressionNodeHandlers.ts
@@ -3,7 +3,6 @@ import { nodeEditorActions } from "~/nodeEditor/nodeEditorActions";
 import { getActionState, getAreaActionState } from "~/state/stateUtils";
 import { getExpressionUpdateIO } from "~/nodeEditor/nodes/expression/expressionUtils";
 import { ValueType } from "~/types";
-import { NodeEditorAreaState } from "~/nodeEditor/nodeEditorAreaReducer";
 import { transformGlobalToNodeEditorPosition } from "~/nodeEditor/nodeEditorUtils";
 import { getDistance } from "~/util/math";
 import { NODE_EDITOR_EXPRESSION_NODE_MIN_TEXTAREA_HEIGHT, AreaType } from "~/constants";
@@ -68,7 +67,7 @@ export const expressionNodeHandlers = {
 		requestAction(
 			{ history: true },
 			({ submitAction, cancelAction, dispatch, addListener }) => {
-				const { pan, scale } = getAreaActionState<NodeEditorAreaState>(areaId);
+				const { pan, scale } = getAreaActionState<AreaType.NodeEditor>(areaId);
 
 				const viewport = getAreaViewport(areaId, AreaType.NodeEditor);
 				const transformMousePosition = (mousePosition: Vec2) =>

--- a/src/nodeEditor/nodes/nodeHandlers.ts
+++ b/src/nodeEditor/nodes/nodeHandlers.ts
@@ -2,7 +2,6 @@ import { requestAction, RequestActionCallback } from "~/listener/requestAction";
 import { isKeyDown } from "~/listener/keyboard";
 import { getActionState, getAreaActionState } from "~/state/stateUtils";
 import { getDistance } from "~/util/math";
-import { NodeEditorAreaState } from "~/nodeEditor/nodeEditorAreaReducer";
 import { transformGlobalToNodeEditorPosition } from "~/nodeEditor/nodeEditorUtils";
 import { nodeEditorActions } from "~/nodeEditor/nodeEditorActions";
 import { contextMenuActions } from "~/contextMenu/contextMenuActions";
@@ -139,7 +138,7 @@ export const nodeHandlers = {
 			({ submitAction, dispatch, addListener }) => {
 				const shiftKeyDownAtMouseDown = isKeyDown("Shift");
 
-				const { pan, scale } = getAreaActionState<NodeEditorAreaState>(areaId);
+				const { pan, scale } = getAreaActionState<AreaType.NodeEditor>(areaId);
 
 				const viewport = getAreaViewport(areaId, AreaType.NodeEditor);
 				const transformMousePosition = (mousePosition: Vec2) =>
@@ -203,7 +202,7 @@ export const nodeHandlers = {
 		requestAction(
 			{ history: true },
 			({ dispatch, addListener, submitAction, cancelAction }) => {
-				const { pan, scale } = getAreaActionState<NodeEditorAreaState>(areaId);
+				const { pan, scale } = getAreaActionState<AreaType.NodeEditor>(areaId);
 				const graph = getActionState().nodeEditor.graphs[graphId];
 
 				const viewport = getAreaViewport(areaId, AreaType.NodeEditor);
@@ -271,7 +270,7 @@ export const nodeHandlers = {
 			submitAction,
 			cancelAction,
 		}) => {
-			const { pan, scale } = getAreaActionState<NodeEditorAreaState>(areaId);
+			const { pan, scale } = getAreaActionState<AreaType.NodeEditor>(areaId);
 			const graph = getActionState().nodeEditor.graphs[graphId];
 
 			const viewport = getAreaViewport(areaId, AreaType.NodeEditor);
@@ -339,7 +338,7 @@ export const nodeHandlers = {
 			submitAction,
 			cancelAction,
 		}) => {
-			const { pan, scale } = getAreaActionState<NodeEditorAreaState>(areaId);
+			const { pan, scale } = getAreaActionState<AreaType.NodeEditor>(areaId);
 			const graph = getActionState().nodeEditor.graphs[graphId];
 
 			const viewport = getAreaViewport(areaId, AreaType.NodeEditor);
@@ -426,7 +425,7 @@ export const nodeHandlers = {
 		requestAction(
 			{ history: true },
 			({ submitAction, cancelAction, dispatch, addListener }) => {
-				const { pan, scale } = getAreaActionState<NodeEditorAreaState>(areaId);
+				const { pan, scale } = getAreaActionState<AreaType.NodeEditor>(areaId);
 
 				const viewport = getAreaViewport(areaId, AreaType.NodeEditor);
 				const transformMousePosition = (mousePosition: Vec2) =>

--- a/src/nodeEditor/util/nodeEditorContextMenu.ts
+++ b/src/nodeEditor/util/nodeEditorContextMenu.ts
@@ -5,7 +5,7 @@ import { contextMenuActions } from "~/contextMenu/contextMenuActions";
 import { transformGlobalToNodeEditorPosition } from "~/nodeEditor/nodeEditorUtils";
 import { NodeEditorNodeInput, NodeEditorNodeOutput } from "~/nodeEditor/nodeEditorIO";
 import { getActionState, getAreaActionState } from "~/state/stateUtils";
-import { NodeEditorAreaState } from "~/nodeEditor/nodeEditorAreaReducer";
+import { AreaType } from "~/constants";
 
 interface Options {
 	graphId: string;
@@ -26,7 +26,7 @@ export const getNodeEditorContextMenuOptions = (options: Options) => {
 		(propertyId) => actionState.compositions.properties[propertyId],
 	);
 
-	const { scale, pan } = getAreaActionState<NodeEditorAreaState>(areaId);
+	const { scale, pan } = getAreaActionState<AreaType.NodeEditor>(areaId);
 
 	interface AddNodeOptions {
 		label: string;

--- a/src/state/reducers.ts
+++ b/src/state/reducers.ts
@@ -1,5 +1,5 @@
 import { combineReducers } from "redux";
-import { AreaState, areaReducer, initialAreaState } from "~/area/state/areaReducer";
+import { AreaReducerState, areaReducer, initialAreaState } from "~/area/state/areaReducer";
 import { ActionBasedState, createActionBasedReducer } from "~/state/history/actionBasedReducer";
 import { ToolState, toolReducer, initialToolState } from "~/toolbar/toolReducer";
 import {
@@ -32,7 +32,7 @@ import {
 
 declare global {
 	interface ApplicationState {
-		area: ActionBasedState<AreaState>;
+		area: ActionBasedState<AreaReducerState>;
 		compositions: HistoryState<CompositionState>;
 		compositionSelection: HistoryState<CompositionSelectionState>;
 		nodeEditor: HistoryState<NodeEditorState>;
@@ -43,7 +43,7 @@ declare global {
 	}
 
 	interface ActionState {
-		area: AreaState;
+		area: AreaReducerState;
 		compositions: CompositionState;
 		compositionSelection: CompositionSelectionState;
 		nodeEditor: NodeEditorState;

--- a/src/state/stateUtils.ts
+++ b/src/state/stateUtils.ts
@@ -2,6 +2,8 @@ import { connect, DispatchProp, InferableComponentEnhancerWithProps } from "reac
 import { store } from "~/state/store";
 import { HistoryState } from "~/state/history/historyReducer";
 import { ActionBasedState } from "~/state/history/actionBasedReducer";
+import { AreaType } from "~/constants";
+import { AreaState } from "~/types/areaTypes";
 
 const getCurrentStateFromApplicationState = (_state: ApplicationState): ActionState => {
 	const state: any = _state;
@@ -84,9 +86,9 @@ export function connectActionState<TStateProps = {}, TOwnProps = {}>(
 export const getActionState = () => getActionStateFromApplicationState(store.getState());
 export const getCurrentState = () => getCurrentStateFromApplicationState(store.getState());
 
-export const getAreaActionState = <T>(areaId: string): T => {
+export const getAreaActionState = <T extends AreaType>(areaId: string): AreaState<T> => {
 	const actionState = getActionState();
-	return actionState.area.areas[areaId].state;
+	return actionState.area.areas[areaId].state as AreaState<T>;
 };
 
 export const getActionId = () => store.getState().area.action?.id || null;

--- a/src/timeline/timelineHandlers.ts
+++ b/src/timeline/timelineHandlers.ts
@@ -13,10 +13,8 @@ import { isKeyDown } from "~/listener/keyboard";
 import { createToTimelineViewportY, createToTimelineViewportX } from "~/timeline/renderTimeline";
 import { getActionState, getAreaActionState } from "~/state/stateUtils";
 import { areaActions } from "~/area/state/areaActions";
-import {
-	compositionTimelineAreaActions,
-	CompositionTimelineAreaState,
-} from "~/composition/timeline/compositionTimelineAreaReducer";
+import { compositionTimelineAreaActions } from "~/composition/timeline/compositionTimelineAreaReducer";
+import { AreaType } from "~/constants";
 
 const PAN_FAC = 0.0004;
 const MIN_DIST = 6;
@@ -753,7 +751,7 @@ export const timelineHandlers = {
 					timelines.forEach(({ id }) => dispatch(timelineActions.clearSelection(id)));
 				}
 
-				const { dragSelectRect } = getAreaActionState<CompositionTimelineAreaState>(
+				const { dragSelectRect } = getAreaActionState<AreaType.CompositionTimeline>(
 					options.compositionTimelineAreaId,
 				);
 

--- a/src/types/areaTypes.ts
+++ b/src/types/areaTypes.ts
@@ -3,7 +3,7 @@ import { NodeEditorAreaState } from "~/nodeEditor/nodeEditorAreaReducer";
 import { CompositionTimelineAreaState } from "~/composition/timeline/compositionTimelineAreaReducer";
 import { CompositionWorkspaceAreaState } from "~/composition/workspace/compositionWorkspaceAreaReducer";
 
-interface _AreaWindowStates {
+interface _AreaStates {
 	[AreaType.NodeEditor]: NodeEditorAreaState;
 	[AreaType.CompositionTimeline]: CompositionTimelineAreaState;
 	[AreaType.CompositionWorkspace]: CompositionWorkspaceAreaState;
@@ -11,7 +11,7 @@ interface _AreaWindowStates {
 	[AreaType.History]: {};
 }
 
-export type AreaState<T extends AreaType> = _AreaWindowStates[T];
+export type AreaState<T extends AreaType> = _AreaStates[T];
 
 export interface Area<T extends AreaType = AreaType> {
 	type: T;

--- a/src/types/areaTypes.ts
+++ b/src/types/areaTypes.ts
@@ -1,3 +1,23 @@
+import { AreaType } from "~/constants";
+import { NodeEditorAreaState } from "~/nodeEditor/nodeEditorAreaReducer";
+import { CompositionTimelineAreaState } from "~/composition/timeline/compositionTimelineAreaReducer";
+import { CompositionWorkspaceAreaState } from "~/composition/workspace/compositionWorkspaceAreaReducer";
+
+interface _AreaWindowStates {
+	[AreaType.NodeEditor]: NodeEditorAreaState;
+	[AreaType.CompositionTimeline]: CompositionTimelineAreaState;
+	[AreaType.CompositionWorkspace]: CompositionWorkspaceAreaState;
+	[AreaType.VectorEditor]: {};
+	[AreaType.History]: {};
+}
+
+export type AreaState<T extends AreaType> = _AreaWindowStates[T];
+
+export interface Area<T extends AreaType = AreaType> {
+	type: T;
+	state: AreaState<T>;
+}
+
 export interface AreaLayout {
 	type: "area";
 	id: string;
@@ -12,7 +32,7 @@ export type AreaRowLayout = {
 
 export type AreaLayoutType = AreaLayout["type"] | AreaRowLayout["type"];
 
-export interface AreaWindowProps<T> {
+export interface AreaComponentProps<T> {
 	width: number;
 	height: number;
 	left: number;

--- a/src/util/mapUtils.ts
+++ b/src/util/mapUtils.ts
@@ -21,3 +21,14 @@ export const addListToMap = <M extends { [key: string]: T }, T>(
 		}, {} as M),
 	};
 };
+
+export const modifyItemInMap = <M extends { [key: string]: T }, T = M[string]>(
+	map: M,
+	id: string,
+	fn: (item: T) => T,
+): M => {
+	return {
+		...map,
+		[id]: fn(map[id]),
+	};
+};

--- a/src/util/math.ts
+++ b/src/util/math.ts
@@ -164,6 +164,18 @@ export const translateRectAsVec = (rect: Rect, transformFn: (vec: Vec2) => Vec2)
 	return { left, top, width, height };
 };
 
+export const contractRect = (rect: Rect, contractBy: number): Rect => {
+	return {
+		left: rect.left + contractBy,
+		top: rect.top + contractBy,
+		width: rect.width - contractBy * 2,
+		height: rect.height - contractBy * 2,
+	};
+};
+
+export const expandRect = (rect: Rect, contractBy: number): Rect =>
+	contractRect(rect, contractBy * -1);
+
 export const splitRect = (
 	type: "horizontal" | "vertical",
 	rect: Rect,

--- a/src/vectorEditor/VectorEditor.tsx
+++ b/src/vectorEditor/VectorEditor.tsx
@@ -1,12 +1,12 @@
 import React, { useRef } from "react";
 import { connectActionState } from "~/state/stateUtils";
 import { compileStylesheetLabelled } from "~/util/stylesheets";
-import { AreaWindowProps } from "~/types/areaTypes";
+import { AreaComponentProps } from "~/types/areaTypes";
 import styles from "~/vectorEditor/VectorEditor.styles";
 
 const s = compileStylesheetLabelled(styles);
 
-type OwnProps = AreaWindowProps<any>;
+type OwnProps = AreaComponentProps<any>;
 type Props = OwnProps;
 
 const VectorEditorComponent: React.FC<Props> = (props) => {

--- a/static/css/base.css
+++ b/static/css/base.css
@@ -11,8 +11,16 @@ html {
 	font-weight: 400;
 }
 
+* {
+	font-family: "Open Sans", sans-serif;
+	text-rendering: optimizeLegibility;
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
+}
+
 html,
 body {
 	margin: 0;
 	padding: 0;
+	overflow: hidden;
 }


### PR DESCRIPTION
Closes #6 

# Changes

## Create and Delete Graphs

The Graph Icon of each layer is now gray when no graph is associated with the layer.

![image](https://user-images.githubusercontent.com/20321920/85930080-0de02a80-b8a9-11ea-97e9-0addb31e50e9.png)

If a graph exists for a layer (`graphId` is not empty), then the icon will be shown in blue. Alongside it, an "Open in Area" icon will be shown.

![image](https://user-images.githubusercontent.com/20321920/85930130-3405ca80-b8a9-11ea-8825-9461cf4e7ff9.png)

If the user clicks on the Graph Icon when it is disabled (gray), a new graph will be created for the layer.

If the user clicks on the Graph Icon when it is active (primary), the associated graph will be deleted.

The "Open in Area" Icon's behavior is described below.


## Open in Area

Added `areaToOpen` to `AreaReducerState`.

When the user clicks and drags from an "Open in Area" icon, a preview of the area to be opened will be displayed at a reduced scale. The size of the preview matches the size of the target area. The target area will be lightly highlighted in blue.

![open in area](https://user-images.githubusercontent.com/20321920/85930058-e38e6d00-b8a8-11ea-85e8-05ce83911d0c.gif)

The "Open in Area" icon (rightmost) looks like so:

![image](https://user-images.githubusercontent.com/20321920/85929383-ce630f80-b8a3-11ea-9a23-7a4258a4bfff.png)


## Create `useVec2TransitionState ` and `useNumberTransitionState`

Usage is identical to `useState`.

```tsx
const [value, setValue] = useNumberTransitionState(0);

// ...

setValue(someValue);
```

When `setValue` is called, the transition to that value is animated. This is useful for animating between values when a value changes intermittently.

Note that these hooks use `useState` internally so while animating between these values the component will be rerendered on each frame. This may cause performance issues if used without consideration.


## Allow `animate` promises to be cancelled.

The `animate` fn now returns `Promise<boolean> & { cancel: () => void }`. The boolean resolved by the promise tells the user whether the animation was cancelled or not.

We make use of this in the new hooks introduced above.


## No default graph open by default

When you switch to the Node Editor, no graph is now open by default. For now this means that graphs can only be opened via the new "Open in Area" behavior.


## Rename area type names

```
AreaState > AreaReducerState
AreaWindowProps > AreaComponentProps
```


## Refactor area types

Create `AreaState<T>`.

```tsx
interface _AreaStates {
	[AreaType.NodeEditor]: NodeEditorAreaState;
	[AreaType.CompositionTimeline]: CompositionTimelineAreaState;
	[AreaType.CompositionWorkspace]: CompositionWorkspaceAreaState;
	[AreaType.VectorEditor]: {};
	[AreaType.History]: {};
}

export type AreaState<T extends AreaType> = _AreaStates[T];
```

This allows us to avoid importing specific area states directly.

The `areaStateReducerRegistry` is now properly typed.

```tsx
export const areaStateReducerRegistry: {
	[T in AreaType]: (state: AreaState<T>, action: any) => AreaState<T>;
} = {
  // ...
}
```
 
The new `Area` interface makes use of `AreaState`.

```tsx
export interface Area<T extends AreaType = AreaType> {
	type: T;
	state: AreaState<T>;
}
```


## Map util `modifyItemInMap`

```tsx
export const modifyItemInMap = <M extends { [key: string]: T }, T = M[string]>(
	map: M,
	id: string,
	fn: (item: T) => T,
): M => {
	return {
		...map,
		[id]: fn(map[id]),
	};
};
```

Usage example: 

```tsx
case getType(compositionActions.setLayerGraphId): {
	const { layerId, graphId } = action.payload;
	return {
		...state,
		layers: modifyItemInMap(state.layers, layerId, (layer) => ({
			...layer,
			graphId,
		})),
	};
}
```


## Rect utils `contractRect` and `expandRect`

Contracts/expands a rect from the center similar to Photoshop selection expansions/contractions.

```tsx
export const contractRect = (rect: Rect, contractBy: number): Rect => {
	return {
		left: rect.left + contractBy,
		top: rect.top + contractBy,
		width: rect.width - contractBy * 2,
		height: rect.height - contractBy * 2,
	};
};

export const expandRect = (rect: Rect, contractBy: number): Rect =>
	contractRect(rect, contractBy * -1);
```