### PR TITLE
Select Layer for `property_input` nodes

### DIFF
--- a/src/nodeEditor/graph/computeNode.ts
+++ b/src/nodeEditor/graph/computeNode.ts
@@ -349,7 +349,7 @@ export const computeNodeOutputArgs = (
 	}
 
 	const inputs = node.inputs.map(({ pointer, type, value: _value }, i) => {
-		const value = nodeToUse?.inputs[i]?.value ?? _value;
+		const value = nodeToUse?.inputs[i].value ?? _value;
 		let defaultValue = { type, value };
 
 		if (!pointer || !ctx.computed[pointer.nodeId]) {

--- a/src/nodeEditor/graph/createLayerGraph.ts
+++ b/src/nodeEditor/graph/createLayerGraph.ts
@@ -11,7 +11,7 @@ export const createLayerGraph = (layerId: string): NodeEditorGraphState => {
 			[nodeId]: {
 				id: nodeId,
 				position: Vec2.new(0, 0),
-				state: { propertyId: "" },
+				state: { layerId: "", propertyId: "" },
 				type: NodeEditorNodeType.property_output,
 				width: DEFAULT_NODE_EDITOR_NODE_WIDTH,
 				outputs: [],

--- a/src/nodeEditor/nodeEditorIO.ts
+++ b/src/nodeEditor/nodeEditorIO.ts
@@ -315,7 +315,7 @@ type NodeEditorNodeStateMap = {
 	[NodeEditorNodeType.vec2_input]: {};
 	[NodeEditorNodeType.empty]: {};
 	[NodeEditorNodeType.rect_translate]: {};
-	[NodeEditorNodeType.property_input]: { propertyId: string };
+	[NodeEditorNodeType.property_input]: { layerId: string; propertyId: string };
 	[NodeEditorNodeType.property_output]: { propertyId: string };
 	[NodeEditorNodeType.expr]: {
 		expression: string;

--- a/src/nodeEditor/nodes/Node.styles.ts
+++ b/src/nodeEditor/nodes/Node.styles.ts
@@ -26,6 +26,9 @@ export default ({ css }: StyleParams) => ({
 		color: ${cssVariables.white500};
 		background: ${cssVariables.gray700};
 		padding-left: 16px;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+		overflow-x: hidden;
 	`,
 
 	input: css`

--- a/src/nodeEditor/nodes/property/PropertyInputNode.tsx
+++ b/src/nodeEditor/nodes/property/PropertyInputNode.tsx
@@ -35,6 +35,22 @@ type Props = OwnProps & StateProps;
 function PropertyInputNodeComponent(props: Props) {
 	const { areaId, graphId, nodeId, outputs } = props;
 
+	const onSelectLayer = (layerId: string) => {
+		requestAction({ history: true }, (params) => {
+			params.dispatch(
+				nodeEditorActions.removeReferencesToNodeInGraph(props.graphId, props.nodeId),
+				nodeEditorActions.updateNodeState<NodeEditorNodeType.property_input>(
+					props.graphId,
+					props.nodeId,
+					{ layerId, propertyId: "" },
+				),
+				nodeEditorActions.setNodeOutputs(props.graphId, props.nodeId, []),
+			);
+
+			params.submitAction("Update selected PropertyInputNode property");
+		});
+	};
+
 	const onSelectProperty = (propertyId: string) => {
 		requestAction({ history: true }, (params) => {
 			params.dispatch(
@@ -83,7 +99,9 @@ function PropertyInputNodeComponent(props: Props) {
 			<PropertyNodeSelectProperty
 				layerId={props.layerId}
 				onSelectProperty={onSelectProperty}
+				onSelectLayer={onSelectLayer}
 				selectedPropertyId={props.state.propertyId}
+				selectedLayerId={props.state.layerId}
 			/>
 			{outputs.map((output, i) => {
 				return (

--- a/src/nodeEditor/util/calculateNodeHeight.ts
+++ b/src/nodeEditor/util/calculateNodeHeight.ts
@@ -54,7 +54,7 @@ const aboveOutputs: Partial<
 	{ [key in NodeEditorNodeType]: (node: NodeEditorNode<any>) => number }
 > = {
 	[NodeEditorNodeType.property_input]: () => {
-		return selectHeight + spacing;
+		return selectHeight + spacing + selectHeight + spacing;
 	},
 	[NodeEditorNodeType.property_output]: () => {
 		return selectHeight + spacing;
@@ -79,7 +79,6 @@ export const getAboveInputs = (node: NodeEditorNode<NodeEditorNodeType>): number
 
 export const calculateNodeHeight = (node: NodeEditorNode<NodeEditorNodeType>): number => {
 	const outputs = node.outputs;
-	console.log(node.type);
 	return (
 		borderWidth * 2 +
 		headerHeight +


### PR DESCRIPTION
# Changes

## Add `layerId` to `property_input` node state

When a `property_input` is created, the initial state is `{ layerId: "", propertyId: "" }`. This looks like so:

![image](https://user-images.githubusercontent.com/20321920/87052168-00ec0100-c1f0-11ea-810d-14c0aff4eeae.png)

When clicked, a context menu is opened where the user can select a layer.

![image](https://user-images.githubusercontent.com/20321920/87052244-13fed100-c1f0-11ea-84fb-09d0ebca35a7.png)

When a layer has been selected, the property select is shown.

![image](https://user-images.githubusercontent.com/20321920/87052283-1f51fc80-c1f0-11ea-8d74-91081f2e511d.png)

The properties in the context menu are all of the properties of the layer.

![image](https://user-images.githubusercontent.com/20321920/87052531-68a24c00-c1f0-11ea-835f-256ba873ff7b.png)

When the layer and property are selected, the node looks like so:

![image](https://user-images.githubusercontent.com/20321920/87052321-2da01880-c1f0-11ea-9fa2-538b82e1b6af.png)

If the layer is changed, all outputs are removed and the property is reset to "Not selected".


## Add safety checks before using `mostRecentNode`

We compute and sort the nodes to compute in the graph from the history state, and then run the action state through that structure. This avoids us having to recompute the graph when scrubbing through the timeline or when dragging a property value.

The `mostRecentNode` is the node from the current action state, while the `node` is from the history state.

There may be differences in the IO of the node and most recent node. For example when changing the `layerId` of the `property_input` node which removes all outputs for the node. 

Since the structure is not recomputed until the action is submitted, other nodes' references to the node whose IO is different have not changed.

To get around this, we can check whether the usage of the most recent node could cause errors. We check whether the number of IO and the types of the IO match the current node's IO.

```tsx
let nodeToUse = mostRecentNode;

// Check whether or not we can make use of mostRecentNode
nodeToUse: {
	if (!nodeToUse) {
		nodeToUse = node;
		break nodeToUse;
	}

	for (let i = 0; i < node.inputs.length; i += 1) {
		const a = node.inputs[i];
		const b = nodeToUse.inputs[i];

		if (!b || a.type !== b.type) {
			nodeToUse = node;
			break nodeToUse;
		}
	}

	for (let i = 0; i < node.outputs.length; i += 1) {
		const a = node.outputs[i];
		const b = nodeToUse.outputs[i];

		if (!b || a.type !== b.type) {
			nodeToUse = node;
			break nodeToUse;
		}
	}
}
```


## Node text overflow

Text overflowing is common in the Node Editor. The node header and selects in `PropertyNodeSelectProperty` now use ellipsis overflow.

![image](https://user-images.githubusercontent.com/20321920/87051920-b8344800-c1ef-11ea-8be7-9b64a4739337.png)







