### PR TITLE
Composition Rendering Improvements and Fixes

### DIFF
--- a/src/composition/hook/useLayerNameToProperty.ts
+++ b/src/composition/hook/useLayerNameToProperty.ts
@@ -1,35 +1,24 @@
-import { useContext } from "react";
-import { computeLayerTransformMap } from "~/composition/transformUtils";
 import { getLayerCompositionProperties } from "~/composition/util/compositionPropertyUtils";
 import { useActionState } from "~/hook/useActionState";
-import { CompositionPropertyValuesContext } from "~/shared/property/computeCompositionPropertyValues";
-import { PropertyName } from "~/types";
+import { CompositionRenderValues, PropertyName } from "~/types";
 
-export const useLayerNameToProperty = (compositionId: string, layerId: string) => {
-	const propertyToValue = useContext(CompositionPropertyValuesContext);
-
+export const useLayerNameToProperty = (
+	map: CompositionRenderValues,
+	_compositionId: string,
+	layerId: string,
+) => {
 	return useActionState((state) => {
 		const properties = getLayerCompositionProperties(layerId, state.compositionState);
 		const nameToProperty = properties.reduce<{ [key in keyof typeof PropertyName]: any }>(
 			(obj, p) => {
-				const value = propertyToValue[p.id];
+				const value = map.properties[p.id];
 				(obj as any)[PropertyName[p.name]] = value.computedValue;
 				return obj;
 			},
 			{} as any,
 		);
 
-		const transformMap = computeLayerTransformMap(
-			compositionId,
-			propertyToValue,
-			state.compositionState,
-		);
-
-		if (!transformMap[layerId]) {
-			return nameToProperty;
-		}
-
-		const { scale, rotation, translate, anchor } = transformMap[layerId];
+		const { scale, rotation, translate, anchor } = map.transforms[layerId];
 
 		return {
 			...nameToProperty,

--- a/src/composition/timeline/CompTime.tsx
+++ b/src/composition/timeline/CompTime.tsx
@@ -18,7 +18,7 @@ import { getCompSelectionFromState } from "~/composition/util/compSelectionUtils
 import { COMP_TIME_SEPARATOR_WIDTH } from "~/constants";
 import { useKeyDownEffect } from "~/hook/useKeyDown";
 import { requestAction, RequestActionCallback } from "~/listener/requestAction";
-import { CompositionPropertyValuesProvider } from "~/shared/property/computeCompositionPropertyValues";
+import { CompositionPropertyValuesProvider } from "~/shared/composition/compositionRenderValues";
 import { connectActionState } from "~/state/stateUtils";
 import { TimelineEditor } from "~/timeline/TimelineEditor";
 import { ViewBounds } from "~/timeline/ViewBounds";

--- a/src/composition/timeline/layer/compTimeLayerParentHandlers.ts
+++ b/src/composition/timeline/layer/compTimeLayerParentHandlers.ts
@@ -15,13 +15,14 @@ const getTransformMap = (compositionId: string) => {
 
 	const { frameIndex, width, height } = compositionState.compositions[compositionId];
 
-	const propertyToValue = computeCompositionPropertyValues(
+	const map = computeCompositionPropertyValues(
 		actionState,
 		compositionId,
 		frameIndex,
 		{ width, height },
+		{ recursive: false },
 	);
-	const transformMap = computeLayerTransformMap(compositionId, propertyToValue, compositionState);
+	const transformMap = computeLayerTransformMap(compositionId, map.properties, compositionState);
 	return transformMap;
 };
 

--- a/src/composition/timeline/layer/compTimeLayerParentHandlers.ts
+++ b/src/composition/timeline/layer/compTimeLayerParentHandlers.ts
@@ -6,7 +6,7 @@ import {
 } from "~/composition/transformUtils";
 import { RAD_TO_DEG_FAC } from "~/constants";
 import { requestAction } from "~/listener/requestAction";
-import { computeCompositionPropertyValues } from "~/shared/property/computeCompositionPropertyValues";
+import { getCompositionRenderValues } from "~/shared/composition/compositionRenderValues";
 import { getActionState } from "~/state/stateUtils";
 
 const getTransformMap = (compositionId: string) => {
@@ -15,7 +15,7 @@ const getTransformMap = (compositionId: string) => {
 
 	const { frameIndex, width, height } = compositionState.compositions[compositionId];
 
-	const map = computeCompositionPropertyValues(
+	const map = getCompositionRenderValues(
 		actionState,
 		compositionId,
 		frameIndex,

--- a/src/composition/timeline/property/value/CompTimePropertyValue.tsx
+++ b/src/composition/timeline/property/value/CompTimePropertyValue.tsx
@@ -2,7 +2,7 @@ import React, { useContext } from "react";
 import { CompositionProperty } from "~/composition/compositionTypes";
 import { CompTimePropertyColorValue } from "~/composition/timeline/property/value/CompTimePropertyColorValue";
 import { CompTimePropertyNumberValue } from "~/composition/timeline/property/value/CompTimePropertyNumberValue";
-import { CompositionPropertyValuesContext } from "~/shared/property/computeCompositionPropertyValues";
+import { CompositionPropertyValuesContext } from "~/shared/composition/compositionRenderValues";
 import { connectActionState } from "~/state/stateUtils";
 import { RGBAColor, ValueType } from "~/types";
 

--- a/src/composition/workspace/CompWorkspace.tsx
+++ b/src/composition/workspace/CompWorkspace.tsx
@@ -5,11 +5,13 @@ import { compositionActions } from "~/composition/state/compositionReducer";
 import { CompositionWorkspaceAreaState } from "~/composition/workspace/compositionWorkspaceAreaReducer";
 import { compositionWorkspaceHandlers } from "~/composition/workspace/compositionWorkspaceHandlers";
 import styles from "~/composition/workspace/CompWorkspace.styles";
+import { CompWorkspaceViewportContext } from "~/composition/workspace/CompWorkspaceViewportContext";
 import { CompWorkspaceCompChildren } from "~/composition/workspace/layers/CompWorkspaceCompChildren";
 import { cssVariables } from "~/cssVariables";
 import { useActionState } from "~/hook/useActionState";
 import { useKeyDownEffect } from "~/hook/useKeyDown";
 import { requestAction, RequestActionParams } from "~/listener/requestAction";
+import { computeCompositionPropertyValues } from "~/shared/property/computeCompositionPropertyValues";
 import { connectActionState } from "~/state/stateUtils";
 import { AreaComponentProps } from "~/types/areaTypes";
 import { separateLeftRightMouse } from "~/util/mouse";
@@ -89,6 +91,20 @@ const CompositionWorkspaceComponent: React.FC<Props> = (props) => {
 	const propsRef = useRef(props);
 	propsRef.current = props;
 
+	const map = useActionState((state) => {
+		const composition = state.compositionState.compositions[props.areaState.compositionId];
+		return computeCompositionPropertyValues(
+			state,
+			composition.id,
+			composition.frameIndex,
+			{
+				width: composition.width,
+				height: composition.height,
+			},
+			{ recursive: true },
+		);
+	});
+
 	return (
 		<>
 			<div className={s("header")}></div>
@@ -113,12 +129,14 @@ const CompositionWorkspaceComponent: React.FC<Props> = (props) => {
 							<CompositionPlaybackProvider
 								compositionId={props.areaState.compositionId}
 							>
-								<CompWorkspaceCompChildren
-									compositionId={composition.id}
-									frameIndex={props.frameIndex}
-									containerHeight={composition.height}
-									containerWidth={composition.width}
-								/>
+								<CompWorkspaceViewportContext.Provider value={{ scale }}>
+									<CompWorkspaceCompChildren
+										compositionId={composition.id}
+										containerHeight={composition.height}
+										containerWidth={composition.width}
+										map={map}
+									/>
+								</CompWorkspaceViewportContext.Provider>
 							</CompositionPlaybackProvider>
 						</svg>
 					</div>

--- a/src/composition/workspace/CompWorkspace.tsx
+++ b/src/composition/workspace/CompWorkspace.tsx
@@ -11,7 +11,7 @@ import { cssVariables } from "~/cssVariables";
 import { useActionState } from "~/hook/useActionState";
 import { useKeyDownEffect } from "~/hook/useKeyDown";
 import { requestAction, RequestActionParams } from "~/listener/requestAction";
-import { computeCompositionPropertyValues } from "~/shared/property/computeCompositionPropertyValues";
+import { getCompositionRenderValues } from "~/shared/composition/compositionRenderValues";
 import { connectActionState } from "~/state/stateUtils";
 import { AreaComponentProps } from "~/types/areaTypes";
 import { separateLeftRightMouse } from "~/util/mouse";
@@ -93,7 +93,7 @@ const CompositionWorkspaceComponent: React.FC<Props> = (props) => {
 
 	const map = useActionState((state) => {
 		const composition = state.compositionState.compositions[props.areaState.compositionId];
-		return computeCompositionPropertyValues(
+		return getCompositionRenderValues(
 			state,
 			composition.id,
 			composition.frameIndex,

--- a/src/composition/workspace/CompWorkspaceViewportContext.tsx
+++ b/src/composition/workspace/CompWorkspaceViewportContext.tsx
@@ -1,0 +1,3 @@
+import React from "react";
+
+export const CompWorkspaceViewportContext = React.createContext<{ scale: number }>({ scale: 1 });

--- a/src/composition/workspace/compWorkspaceTypes.ts
+++ b/src/composition/workspace/compWorkspaceTypes.ts
@@ -1,0 +1,7 @@
+import { CompositionRenderValues } from "~/types";
+
+export interface CompWorkspaceLayerBaseProps {
+	compositionId: string;
+	layerId: string;
+	map: CompositionRenderValues;
+}

--- a/src/composition/workspace/layers/CompWorkspaceCompChildren.tsx
+++ b/src/composition/workspace/layers/CompWorkspaceCompChildren.tsx
@@ -1,16 +1,16 @@
 import React from "react";
 import { CompWorkspaceCompLayer } from "~/composition/workspace/layers/CompWorkspaceCompLayer";
 import { CompWorkspaceEllipseLayer } from "~/composition/workspace/layers/CompWorkspaceEllipseLayer";
+import { CompWorkspaceLayerGuides } from "~/composition/workspace/layers/CompWorkspaceLayerGuides";
 import { CompWorkspaceRectLayer } from "~/composition/workspace/layers/CompWorkspaceRectLayer";
-import { CompositionPropertyValuesProvider } from "~/shared/property/computeCompositionPropertyValues";
 import { connectActionState } from "~/state/stateUtils";
-import { LayerType } from "~/types";
+import { CompositionRenderValues, LayerType } from "~/types";
 
 interface OwnProps {
 	compositionId: string;
-	frameIndex: number;
 	containerHeight: number;
 	containerWidth: number;
+	map: CompositionRenderValues;
 }
 interface StateProps {
 	layerIds: string[];
@@ -21,48 +21,60 @@ type Props = OwnProps & StateProps;
 const CompWorkspaceCompChildrenComponent: React.FC<Props> = (props) => {
 	const { layerIds, layerTypes } = props;
 
-	// const parentTransforms = useContext(AdditionalTransformContext);
+	const layers: React.ReactNode[] = [];
+
+	const getLayerContent = (i: number) => {
+		const layerId = layerIds[i];
+
+		if (layerTypes[i] === LayerType.Composition) {
+			return (
+				<CompWorkspaceCompLayer
+					key={layerId}
+					compositionId={props.compositionId}
+					layerId={layerId}
+					map={props.map}
+				/>
+			);
+		}
+
+		if (layerTypes[i] === LayerType.Ellipse) {
+			return (
+				<CompWorkspaceEllipseLayer
+					key={layerId}
+					compositionId={props.compositionId}
+					layerId={layerId}
+					map={props.map}
+				/>
+			);
+		}
+
+		return (
+			<CompWorkspaceRectLayer
+				key={layerId}
+				compositionId={props.compositionId}
+				layerId={layerId}
+				map={props.map}
+			/>
+		);
+	};
+
+	for (let i = layerIds.length - 1; i >= 0; i -= 1) {
+		layers.push(getLayerContent(i));
+	}
 
 	return (
-		<CompositionPropertyValuesProvider
-			compositionId={props.compositionId}
-			frameIndex={props.frameIndex}
-			containerWidth={props.containerWidth}
-			containerHeight={props.containerHeight}
-		>
-			{layerIds.map((id, i) => {
-				if (layerTypes[i] === LayerType.Composition) {
-					return (
-						<CompWorkspaceCompLayer
-							key={id}
-							compositionId={props.compositionId}
-							layerId={id}
-							frameIndex={props.frameIndex}
-						/>
-					);
-				}
-
-				if (layerTypes[i] === LayerType.Ellipse) {
-					return (
-						<CompWorkspaceEllipseLayer
-							key={id}
-							compositionId={props.compositionId}
-							layerId={id}
-							frameIndex={props.frameIndex}
-						/>
-					);
-				}
-
-				return (
-					<CompWorkspaceRectLayer
-						key={id}
+		<>
+			{layers}
+			{!props.map.parent &&
+				layerIds.map((layerId) => (
+					<CompWorkspaceLayerGuides
+						key={layerId}
 						compositionId={props.compositionId}
-						layerId={id}
-						frameIndex={props.frameIndex}
+						layerId={layerId}
+						map={props.map}
 					/>
-				);
-			})}
-		</CompositionPropertyValuesProvider>
+				))}
+		</>
 	);
 };
 

--- a/src/composition/workspace/layers/CompWorkspaceCompLayer.tsx
+++ b/src/composition/workspace/layers/CompWorkspaceCompLayer.tsx
@@ -1,77 +1,59 @@
 import React from "react";
 import { CompositionLayer } from "~/composition/compositionTypes";
 import { useLayerNameToProperty } from "~/composition/hook/useLayerNameToProperty";
+import { getCompSelectionFromState } from "~/composition/util/compSelectionUtils";
+import { CompWorkspaceLayerBaseProps } from "~/composition/workspace/compWorkspaceTypes";
 import { CompWorkspaceCompChildren } from "~/composition/workspace/layers/CompWorkspaceCompChildren";
-import { getLayerTransformStyle } from "~/composition/workspace/layers/layerTransformStyle";
 import { useWorkspaceLayerShouldRender } from "~/composition/workspace/useWorkspaceLayerShouldRender";
 import { connectActionState } from "~/state/stateUtils";
 import { AffineTransform } from "~/types";
 
 export const AdditionalTransformContext = React.createContext<AffineTransform[]>([]);
 
-interface OwnProps {
-	compositionId: string;
-	layerId: string;
-	frameIndex: number;
-}
+type OwnProps = CompWorkspaceLayerBaseProps;
 interface StateProps {
 	compositionReferenceId: string;
 	layer: CompositionLayer;
+	selected: boolean;
 }
 type Props = OwnProps & StateProps;
 
 const CompWorkspaceCompLayerComponent: React.FC<Props> = (props) => {
-	const nameToProperty = useLayerNameToProperty(props.compositionId, props.layerId);
-	const shouldRender = useWorkspaceLayerShouldRender(props.layer, props.frameIndex);
+	const { layer, map } = props;
+
+	const nameToProperty = useLayerNameToProperty(map, props.compositionId, layer.id);
+	const shouldRender = useWorkspaceLayerShouldRender(map.frameIndex, layer.index, layer.length);
 
 	if (!shouldRender) {
 		return null;
 	}
 
-	const { PositionX, PositionY, Scale, Opacity, Rotation, AnchorX, AnchorY } = nameToProperty;
-
-	const transformStyle = getLayerTransformStyle(
-		PositionX,
-		PositionY,
-		AnchorX,
-		AnchorY,
-		Rotation,
-		Scale,
-	);
+	const { Opacity } = nameToProperty;
 
 	return (
 		<>
-			<g
-				data-layer-id={props.layerId}
-				style={{
-					opacity: Opacity,
-					...transformStyle,
-				}}
-			>
+			<g data-layer-id={props.layerId} style={{ opacity: Opacity }}>
 				<CompWorkspaceCompChildren
 					compositionId={props.compositionReferenceId}
-					frameIndex={props.frameIndex}
 					containerWidth={nameToProperty.Width}
 					containerHeight={nameToProperty.Height}
+					map={map.compositionLayers[props.layerId]}
 				/>
 			</g>
-			<ellipse
-				cx={PositionX}
-				cy={PositionY}
-				rx={5}
-				ry={5}
-				style={{
-					fill: "cyan",
-				}}
-			/>
 		</>
 	);
 };
 
-const mapState: MapActionState<StateProps, OwnProps> = ({ compositionState }, { layerId }) => {
+const mapState: MapActionState<StateProps, OwnProps> = (
+	{ compositionState, compositionSelectionState },
+	{ layerId },
+) => {
+	const layer = compositionState.layers[layerId];
+	const selection = getCompSelectionFromState(layer.compositionId, compositionSelectionState);
 	return {
 		compositionReferenceId: compositionState.compositionLayerIdToComposition[layerId],
-		layer: compositionState.layers[layerId],
+		layer,
+		selected: !!selection.layers[layerId],
 	};
 };
 

--- a/src/composition/workspace/layers/CompWorkspaceEllipseLayer.tsx
+++ b/src/composition/workspace/layers/CompWorkspaceEllipseLayer.tsx
@@ -2,15 +2,12 @@ import React from "react";
 import { CompositionLayer } from "~/composition/compositionTypes";
 import { useLayerNameToProperty } from "~/composition/hook/useLayerNameToProperty";
 import { getCompSelectionFromState } from "~/composition/util/compSelectionUtils";
+import { CompWorkspaceLayerBaseProps } from "~/composition/workspace/compWorkspaceTypes";
 import { getLayerTransformStyle } from "~/composition/workspace/layers/layerTransformStyle";
 import { useWorkspaceLayerShouldRender } from "~/composition/workspace/useWorkspaceLayerShouldRender";
 import { connectActionState } from "~/state/stateUtils";
 
-interface OwnProps {
-	compositionId: string;
-	layerId: string;
-	frameIndex: number;
-}
+type OwnProps = CompWorkspaceLayerBaseProps;
 interface StateProps {
 	isSelected: boolean;
 	layer: CompositionLayer;
@@ -18,8 +15,10 @@ interface StateProps {
 type Props = OwnProps & StateProps;
 
 const CompWorkspaceEllipseLayerComponent: React.FC<Props> = (props) => {
-	const nameToProperty = useLayerNameToProperty(props.compositionId, props.layerId);
-	const shouldRender = useWorkspaceLayerShouldRender(props.layer, props.frameIndex);
+	const { layer, map } = props;
+
+	const nameToProperty = useLayerNameToProperty(map, props.compositionId, layer.id);
+	const shouldRender = useWorkspaceLayerShouldRender(map.frameIndex, layer.index, layer.length);
 
 	if (!shouldRender) {
 		return null;
@@ -122,7 +121,6 @@ const CompWorkspaceEllipseLayerComponent: React.FC<Props> = (props) => {
 					/>
 				)}
 			</g>
-			<ellipse cx={PositionX} cy={PositionY} rx={5} ry={5} style={{ fill: "cyan" }} />
 		</>
 	);
 };

--- a/src/composition/workspace/layers/CompWorkspaceLayerGuides.tsx
+++ b/src/composition/workspace/layers/CompWorkspaceLayerGuides.tsx
@@ -1,0 +1,203 @@
+import React from "react";
+import { CompositionLayer } from "~/composition/compositionTypes";
+import { useLayerNameToProperty } from "~/composition/hook/useLayerNameToProperty";
+import { getCompSelectionFromState } from "~/composition/util/compSelectionUtils";
+import { CompWorkspaceLayerBaseProps } from "~/composition/workspace/compWorkspaceTypes";
+import { CompWorkspaceViewportContext } from "~/composition/workspace/CompWorkspaceViewportContext";
+import { useWorkspaceLayerShouldRender } from "~/composition/workspace/useWorkspaceLayerShouldRender";
+import { connectActionState } from "~/state/stateUtils";
+import { AffineTransform, LayerType } from "~/types";
+import { rotateVec2CCW } from "~/util/math";
+
+export const AdditionalTransformContext = React.createContext<AffineTransform[]>([]);
+
+type OwnProps = CompWorkspaceLayerBaseProps;
+interface StateProps {
+	compositionReferenceId: string;
+	layer: CompositionLayer;
+	selected: boolean;
+}
+type Props = OwnProps & StateProps;
+
+const CompWorkspaceLayerGuidesComponent: React.FC<Props> = (props) => {
+	const { layer, map } = props;
+
+	const nameToProperty = useLayerNameToProperty(map, props.compositionId, layer.id);
+	const shouldRender = useWorkspaceLayerShouldRender(map.frameIndex, layer.index, layer.length);
+
+	const { scale } = React.useContext(CompWorkspaceViewportContext);
+
+	if (!shouldRender || !props.selected) {
+		return null;
+	}
+
+	let { PositionX, PositionY, Rotation, AnchorX, AnchorY } = nameToProperty;
+
+	let width: number;
+	let height: number;
+
+	switch (layer.type) {
+		case LayerType.Composition: {
+			width = nameToProperty.Width;
+			height = nameToProperty.Height;
+			break;
+		}
+
+		case LayerType.Rect: {
+			width = nameToProperty.Width;
+			height = nameToProperty.Height;
+			break;
+		}
+
+		case LayerType.Ellipse: {
+			width = nameToProperty.OuterRadius * 2;
+			height = nameToProperty.OuterRadius * 2;
+			AnchorX += nameToProperty.OuterRadius;
+			AnchorY += nameToProperty.OuterRadius;
+			break;
+		}
+	}
+
+	const color = "rgb(89 142 243)";
+	const anchorShadowColor = "white";
+
+	const W = 9 / scale;
+	const R = 5 / scale;
+	const S = 1.4 / scale;
+	const A = 3 / scale;
+	const SW = 1 / scale;
+	const SOFF = 1 / scale;
+
+	return (
+		<>
+			{[
+				[0, 0],
+				[0, 1],
+				[1, 0],
+				[1, 1],
+			].map(([x, y], i) => {
+				const pt = map.transforms[props.layerId];
+				const pos = Vec2.new(PositionX + width * x, PositionY + height * y)
+					.sub(Vec2.new(AnchorX, AnchorY))
+					.apply((pos) => rotateVec2CCW(pos, pt.rotation, pt.translate))
+					.scale(pt.scale, pt.translate)
+					.sub(Vec2.new(W / 2, W / 2));
+
+				return (
+					<g key={i}>
+						<rect
+							width={W}
+							height={W}
+							x={pos.x + SOFF}
+							y={pos.y + SOFF}
+							style={{ fill: "black" }}
+						/>
+						<rect width={W} height={W} x={pos.x} y={pos.y} style={{ fill: color }} />
+					</g>
+				);
+			})}
+			<ellipse
+				cx={PositionX}
+				cy={PositionY}
+				rx={R}
+				ry={R}
+				style={{ stroke: anchorShadowColor, strokeWidth: S + SW * 2, fill: "transparent" }}
+			/>
+			<g
+				style={{
+					transformOrigin: `${PositionX}px ${PositionY}px`,
+					transform: `rotate(${Rotation}rad)`,
+				}}
+			>
+				<line
+					y1={PositionY - R}
+					y2={PositionY - (R + A + SW)}
+					x1={PositionX}
+					x2={PositionX}
+					stroke={anchorShadowColor}
+					strokeWidth={S + SW * 2}
+				/>
+				<line
+					y1={PositionY + R}
+					y2={PositionY + (R + A + SW)}
+					x1={PositionX}
+					x2={PositionX}
+					stroke={anchorShadowColor}
+					strokeWidth={S + SW * 2}
+				/>
+				<line
+					y1={PositionY}
+					y2={PositionY}
+					x1={PositionX - R}
+					x2={PositionX - (R + A + SW)}
+					stroke={anchorShadowColor}
+					strokeWidth={S + SW * 2}
+				/>
+				<line
+					y1={PositionY}
+					y2={PositionY}
+					x1={PositionX + R}
+					x2={PositionX + (R + A + SW)}
+					stroke={anchorShadowColor}
+					strokeWidth={S + SW * 2}
+				/>
+				<line
+					y1={PositionY - R}
+					y2={PositionY - (R + A)}
+					x1={PositionX}
+					x2={PositionX}
+					stroke={color}
+					strokeWidth={S}
+				/>
+				<line
+					y1={PositionY + R}
+					y2={PositionY + (R + A)}
+					x1={PositionX}
+					x2={PositionX}
+					stroke={color}
+					strokeWidth={S}
+				/>
+				<line
+					y1={PositionY}
+					y2={PositionY}
+					x1={PositionX - R}
+					x2={PositionX - (R + A)}
+					stroke={color}
+					strokeWidth={S}
+				/>
+				<line
+					y1={PositionY}
+					y2={PositionY}
+					x1={PositionX + R}
+					x2={PositionX + (R + A)}
+					stroke={color}
+					strokeWidth={S}
+				/>
+			</g>
+			<ellipse
+				cx={PositionX}
+				cy={PositionY}
+				rx={R}
+				ry={R}
+				style={{ stroke: color, strokeWidth: S, fill: "transparent" }}
+			/>
+		</>
+	);
+};
+
+const mapState: MapActionState<StateProps, OwnProps> = (
+	{ compositionState, compositionSelectionState },
+	{ layerId },
+) => {
+	const layer = compositionState.layers[layerId];
+	const selection = getCompSelectionFromState(layer.compositionId, compositionSelectionState);
+	return {
+		compositionReferenceId: compositionState.compositionLayerIdToComposition[layerId],
+		layer,
+		selected: !!selection.layers[layerId],
+	};
+};
+
+export const CompWorkspaceLayerGuides = connectActionState(mapState)(
+	CompWorkspaceLayerGuidesComponent,
+);

--- a/src/composition/workspace/layers/CompWorkspaceRectLayer.tsx
+++ b/src/composition/workspace/layers/CompWorkspaceRectLayer.tsx
@@ -6,6 +6,7 @@ import { getLayerTransformStyle } from "~/composition/workspace/layers/layerTran
 import { useWorkspaceLayerShouldRender } from "~/composition/workspace/useWorkspaceLayerShouldRender";
 import { NodeEditorGraphState } from "~/nodeEditor/nodeEditorReducers";
 import { connectActionState } from "~/state/stateUtils";
+import { CompositionRenderValues } from "~/types";
 import { compileStylesheetLabelled, StyleParams } from "~/util/stylesheets";
 
 const styles = ({ css }: StyleParams) => ({
@@ -20,20 +21,20 @@ const s = compileStylesheetLabelled(styles);
 interface OwnProps {
 	compositionId: string;
 	layerId: string;
-	frameIndex: number;
+	map: CompositionRenderValues;
 }
 interface StateProps {
 	layer: CompositionLayer;
 	graph?: NodeEditorGraphState;
-	isSelected: boolean;
+	selected: boolean;
 }
 type Props = OwnProps & StateProps;
 
 const CompWorkspaceRectLayerComponent: React.FC<Props> = (props) => {
-	const { layer } = props;
+	const { layer, map } = props;
 
-	const nameToProperty = useLayerNameToProperty(props.compositionId, layer.id);
-	const shouldRender = useWorkspaceLayerShouldRender(layer, props.frameIndex);
+	const nameToProperty = useLayerNameToProperty(map, props.compositionId, layer.id);
+	const shouldRender = useWorkspaceLayerShouldRender(map.frameIndex, layer.index, layer.length);
 
 	if (!shouldRender) {
 		return null;
@@ -85,7 +86,6 @@ const CompWorkspaceRectLayerComponent: React.FC<Props> = (props) => {
 					...transformStyle,
 				}}
 			/>
-			<ellipse cx={PositionX} cy={PositionY} rx={5} ry={5} style={{ fill: "cyan" }} />
 		</>
 	);
 };
@@ -99,7 +99,7 @@ const mapState: MapActionState<StateProps, OwnProps> = (
 	return {
 		layer,
 		graph: layer.graphId ? nodeEditor.graphs[layer.graphId] : undefined,
-		isSelected: !!selection.layers[layerId],
+		selected: !!selection.layers[layerId],
 	};
 };
 

--- a/src/composition/workspace/useWorkspaceLayerShouldRender.ts
+++ b/src/composition/workspace/useWorkspaceLayerShouldRender.ts
@@ -1,19 +1,19 @@
-import { useContext } from "react";
-import { CompositionLayer } from "~/composition/compositionTypes";
-import {
-	CompositionFrameIndexContext,
-	CompositionLayerShiftContext,
-} from "~/composition/hook/useCompositionPlayback";
+// import { useContext } from "react";
+// import { CompositionLayer } from "~/composition/compositionTypes";
+// import {
+// 	CompositionFrameIndexContext,
+// 	CompositionLayerShiftContext,
+// } from "~/composition/hook/useCompositionPlayback";
 
 export const useWorkspaceLayerShouldRender = (
-	layer: CompositionLayer,
-	compositionFrameIndex: number,
+	frameIndex: number,
+	layerIndex: number,
+	layerLength: number,
 ): boolean => {
-	const layerIndexShiftMap = useContext(CompositionLayerShiftContext);
-	const playbackFrameIndex = useContext(CompositionFrameIndexContext);
+	// const layerIndexShiftMap = useContext(CompositionLayerShiftContext);
+	// const playbackFrameIndex = useContext(CompositionFrameIndexContext);
 
-	const frameIndexToUse = playbackFrameIndex === -1 ? compositionFrameIndex : playbackFrameIndex;
+	// const frameIndexToUse = playbackFrameIndex === -1 ? compositionFrameIndex : playbackFrameIndex;
 
-	const frameIndex = frameIndexToUse + layerIndexShiftMap[layer.id];
-	return !(frameIndex < layer.index || frameIndex > layer.index + layer.length);
+	return !(frameIndex < layerIndex || frameIndex > layerIndex + layerLength);
 };

--- a/src/nodeEditor/graph/computeNode.ts
+++ b/src/nodeEditor/graph/computeNode.ts
@@ -2,7 +2,7 @@ import * as mathjs from "mathjs";
 import { CompositionState } from "~/composition/state/compositionReducer";
 import { DEG_TO_RAD_FAC, RAD_TO_DEG_FAC } from "~/constants";
 import { NodeEditorNode, NodeEditorNodeState } from "~/nodeEditor/nodeEditorIO";
-import { NodeEditorNodeType, RGBAColor, ValueType } from "~/types";
+import { NodeEditorNodeType, PropertyValueMap, RGBAColor, ValueType } from "~/types";
 import { capToRange, interpolate } from "~/util/math";
 
 const Type = NodeEditorNodeType;
@@ -21,15 +21,8 @@ export interface ComputeNodeContext {
 		width: number;
 		height: number;
 	};
-	propertyToValue: {
-		[propertyId: string]: {
-			rawValue: any;
-			computedValue: any;
-		};
-	};
-	layerIdToFrameIndex: {
-		[layerId: string]: number;
-	};
+	propertyToValue: PropertyValueMap;
+	frameIndex: number;
 }
 
 const parseNum = (arg: ComputeNodeArg): number => {
@@ -369,9 +362,7 @@ const compute: {
 	 * Width, Height, Frame
 	 */
 	[Type.composition]: (_args, ctx) => {
-		const { container } = ctx;
-
-		const frameIndex = ctx.layerIdToFrameIndex[ctx.layerId];
+		const { container, frameIndex } = ctx;
 
 		return [
 			toArg.number(container?.width ?? 150),

--- a/src/shared/composition/compositionRenderValues.tsx
+++ b/src/shared/composition/compositionRenderValues.tsx
@@ -39,7 +39,7 @@ interface Options {
 	recursive: boolean;
 }
 
-export const _compute = (context: Context, options: Options): CompositionRenderValues => {
+const _compute = (context: Context, options: Options): CompositionRenderValues => {
 	const {
 		compositionId,
 		compositionState,
@@ -230,7 +230,7 @@ export const _compute = (context: Context, options: Options): CompositionRenderV
 	return crawl(compositionId, frameIndex);
 };
 
-export const computeCompositionPropertyValues = (
+export const getCompositionRenderValues = (
 	state: ActionState,
 	compositionId: string,
 	frameIndex: number,
@@ -262,7 +262,7 @@ export const CompositionPropertyValuesProvider: React.FC<{
 	containerHeight: number;
 }> = ({ children, compositionId, frameIndex, containerWidth, containerHeight }) => {
 	const map = useActionState((state) => {
-		return computeCompositionPropertyValues(
+		return getCompositionRenderValues(
 			state,
 			compositionId,
 			frameIndex,

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,13 @@ export type HSLColor = [number, number, number];
 export type RGBColor = [number, number, number];
 export type RGBAColor = [number, number, number, number];
 
+export interface AffineTransform {
+	translate: Vec2;
+	anchor: Vec2;
+	rotation: number; // Radians
+	scale: number;
+}
+
 export enum NodeEditorNodeType {
 	empty = "empty",
 
@@ -102,9 +109,14 @@ export interface PropertyValueMap {
 	};
 }
 
-export interface AffineTransform {
-	translate: Vec2;
-	anchor: Vec2;
-	rotation: number; // Radians
-	scale: number;
+export interface CompositionRenderValues {
+	properties: PropertyValueMap;
+	transforms: {
+		[layerId: string]: AffineTransform;
+	};
+	compositionLayers: {
+		[layerId: string]: CompositionRenderValues;
+	};
+	frameIndex: number;
+	parent?: CompositionRenderValues;
 }


### PR DESCRIPTION
Closes #37. Closes #21. Closes #34.

# Changes

## Render Composition

We no longer compute a single flat property-to-value map for the composition and all composition layers (deep) within that composition because of the issues described in #37.

We now compute `CompositionRenderValues` at the top composition.

```tsx
export interface CompositionRenderValues {
	properties: PropertyValueMap;
	transforms: {
		[layerId: string]: AffineTransform;
	};
	compositionLayers: {
		[layerId: string]: CompositionRenderValues;
	};
	frameIndex: number;
	parent?: CompositionRenderValues;
}
```

The `properties` is a flat property-to-value map for all of the properties in the composition.

The `transforms` are the transforms of each layer with the parent transforms already applied.

Each composition layer in a composition will receive the `CompositionRenderValues` in `compositionLayers` behind the layer's id. The `transforms` in the `CompositionRenderValues` already have the composition layer's transforms applied to it, so the layers consume the transform in the same way no matter whether they are in a nested composition or not.

The `frameIndex` is the frame index for the composition layer relative to the top-level composition. This makes the "layer shifts" we have been working with redundant.

Context is not used to pass these down, regular props are used.


## Layer transform guides

Layer transform guides are now shown for selected layers in the composition.

![image](https://user-images.githubusercontent.com/20321920/89133047-2bd42700-d508-11ea-8ff2-0457ac0dccfc.png)

Multiple layer guides can be shown at the same time. The guides are shown above all layers.

![image](https://user-images.githubusercontent.com/20321920/89133065-5c1bc580-d508-11ea-8f0b-101f4048f6da.png)


## Simplified Rendering for Nested Compositions

Because of the transform changes mentioned in the first section, the layer rendering no longer needs to be deeply nested. The composite transforms are applied directly to the layer instead of composing them via `g` elements. This provides a much flatter structure than before.

However, we still need to a single `g` around the elements of every composition layer.

![image](https://user-images.githubusercontent.com/20321920/89133109-cd5b7880-d508-11ea-9d7b-75ef5eeadf26.png)

This is so that opacity on a composition layer is applied without creating a see-through effect.

Without see-through:

![image](https://user-images.githubusercontent.com/20321920/89133115-e3693900-d508-11ea-95be-5574004625de.png)

With see-through:

![image](https://user-images.githubusercontent.com/20321920/89133120-fe3bad80-d508-11ea-9306-a5cb1588680a.png)

If the see-through effect is desired, the opacity will have to applied to the individual layers, not the composition layer.

