### PR TITLE
Reorder Layers

### DIFF
--- a/src/area/components/Area.tsx
+++ b/src/area/components/Area.tsx
@@ -4,6 +4,7 @@ import styles from "~/area/components/Area.styles";
 import { AreaErrorBoundary } from "~/area/components/AreaErrorBoundary";
 import { handleAreaDragFromCorner } from "~/area/handlers/areaDragFromCorner";
 import { areaActions } from "~/area/state/areaActions";
+import { AreaIdContext } from "~/area/util/AreaIdContext";
 import { EditIcon } from "~/components/icons/EditIcon";
 import { PenIcon } from "~/components/icons/PenIcon";
 import { AreaType, AREA_BORDER_WIDTH } from "~/constants";
@@ -126,15 +127,17 @@ export const AreaComponent: React.FC<Props> = (props) => {
 				<Icon />
 			</button>
 			<div className={s("area__content")}>
-				<AreaErrorBoundary
-					component={Component}
-					areaId={props.id}
-					areaState={props.state}
-					left={viewport.left + AREA_BORDER_WIDTH}
-					top={viewport.top + AREA_BORDER_WIDTH}
-					width={viewport.width - AREA_BORDER_WIDTH * 2}
-					height={viewport.height - AREA_BORDER_WIDTH * 2}
-				/>
+				<AreaIdContext.Provider value={props.id}>
+					<AreaErrorBoundary
+						component={Component}
+						areaId={props.id}
+						areaState={props.state}
+						left={viewport.left + AREA_BORDER_WIDTH}
+						top={viewport.top + AREA_BORDER_WIDTH}
+						width={viewport.width - AREA_BORDER_WIDTH * 2}
+						height={viewport.height - AREA_BORDER_WIDTH * 2}
+					/>
+				</AreaIdContext.Provider>
 			</div>
 		</div>
 	);

--- a/src/area/util/AreaIdContext.tsx
+++ b/src/area/util/AreaIdContext.tsx
@@ -1,0 +1,3 @@
+import React from "react";
+
+export const AreaIdContext = React.createContext("");

--- a/src/composition/state/compositionSelectionReducer.ts
+++ b/src/composition/state/compositionSelectionReducer.ts
@@ -2,7 +2,7 @@ import { ActionType, createAction, getType } from "typesafe-actions";
 import { CompositionSelection } from "~/composition/compositionTypes";
 import { removeKeysFromMap } from "~/util/mapUtils";
 
-export const compositionSelectionActions = {
+export const compSelectionActions = {
 	toggleLayerSelection: createAction("comp/TOGGLE_LAYER_SELECTED", (action) => {
 		return (compositionId: string, layerId: string) => action({ compositionId, layerId });
 	}),
@@ -44,14 +44,14 @@ const createNewCompSelection = (): CompositionSelection => ({
 	properties: {},
 });
 
-type Action = ActionType<typeof compositionSelectionActions>;
+type Action = ActionType<typeof compSelectionActions>;
 
 const singleCompositionSelectionReducer = (
 	state: CompositionSelection,
 	action: Action,
 ): CompositionSelection => {
 	switch (action.type) {
-		case getType(compositionSelectionActions.toggleLayerSelection): {
+		case getType(compSelectionActions.toggleLayerSelection): {
 			const { layerId } = action.payload;
 
 			return {
@@ -65,7 +65,7 @@ const singleCompositionSelectionReducer = (
 			};
 		}
 
-		case getType(compositionSelectionActions.removeLayersFromSelection): {
+		case getType(compSelectionActions.removeLayersFromSelection): {
 			const { layerIds } = action.payload;
 
 			return {
@@ -74,7 +74,7 @@ const singleCompositionSelectionReducer = (
 			};
 		}
 
-		case getType(compositionSelectionActions.removePropertiesFromSelection): {
+		case getType(compSelectionActions.removePropertiesFromSelection): {
 			const { propertyIds } = action.payload;
 
 			return {
@@ -83,7 +83,7 @@ const singleCompositionSelectionReducer = (
 			};
 		}
 
-		case getType(compositionSelectionActions.togglePropertySelection): {
+		case getType(compSelectionActions.togglePropertySelection): {
 			const { propertyId } = action.payload;
 
 			return {
@@ -97,11 +97,11 @@ const singleCompositionSelectionReducer = (
 			};
 		}
 
-		case getType(compositionSelectionActions.clearCompositionSelection): {
+		case getType(compSelectionActions.clearCompositionSelection): {
 			return { ...state, properties: {}, layers: {} };
 		}
 
-		case getType(compositionSelectionActions.addPropertyToSelection): {
+		case getType(compSelectionActions.addPropertyToSelection): {
 			const { propertyId } = action.payload;
 			return {
 				...state,
@@ -112,7 +112,7 @@ const singleCompositionSelectionReducer = (
 			};
 		}
 
-		case getType(compositionSelectionActions.addLayerToSelection): {
+		case getType(compSelectionActions.addLayerToSelection): {
 			const { layerId } = action.payload;
 			return {
 				...state,

--- a/src/composition/timeline/CompTime.styles.ts
+++ b/src/composition/timeline/CompTime.styles.ts
@@ -39,11 +39,6 @@ export default ({ css }: StyleParams) => ({
 		flex-direction: column;
 	`,
 
-	layerWrapper: css`
-		flex-grow: 1;
-		overflow: hidden;
-	`,
-
 	right: css`
 		background: ${cssVariables.gray500};
 		overflow: hidden;

--- a/src/composition/timeline/CompTime.tsx
+++ b/src/composition/timeline/CompTime.tsx
@@ -9,8 +9,8 @@ import { CompositionState } from "~/composition/state/compositionReducer";
 import styles from "~/composition/timeline/CompTime.styles";
 import { compTimeAreaActions, CompTimeAreaState } from "~/composition/timeline/compTimeAreaReducer";
 import { compTimeHandlers } from "~/composition/timeline/compTimeHandlers";
+import { CompTimeLayerList } from "~/composition/timeline/CompTimeLayerList";
 import { capCompTimePanY } from "~/composition/timeline/compTimeUtils";
-import { CompTimeLayer } from "~/composition/timeline/layer/CompTimeLayer";
 import { CompTimeScrubber } from "~/composition/timeline/scrubber/CompTimeScrubber";
 import { TrackEditor } from "~/composition/timeline/track/TrackEditor";
 import { getLayerCompositionProperties } from "~/composition/util/compositionPropertyUtils";
@@ -18,7 +18,6 @@ import { getCompSelectionFromState } from "~/composition/util/compSelectionUtils
 import { COMP_TIME_SEPARATOR_WIDTH } from "~/constants";
 import { useKeyDownEffect } from "~/hook/useKeyDown";
 import { requestAction, RequestActionCallback } from "~/listener/requestAction";
-import { CompositionPropertyValuesProvider } from "~/shared/composition/compositionRenderValues";
 import { connectActionState } from "~/state/stateUtils";
 import { TimelineEditor } from "~/timeline/TimelineEditor";
 import { ViewBounds } from "~/timeline/ViewBounds";
@@ -206,26 +205,11 @@ const CompTimeComponent: React.FC<Props> = (props) => {
 						Graph Editor
 					</button>
 				</div>
-				<CompositionPropertyValuesProvider
+				<CompTimeLayerList
 					compositionId={composition.id}
-					frameIndex={composition.frameIndex}
-					containerWidth={composition.width}
-					containerHeight={composition.height}
-				>
-					<div className={s("layerWrapper")} data-ct-composition-id={composition.id}>
-						<div style={{ transform: `translateY(${-panY}px)` }}>
-							{composition.layers.map((layerId) => {
-								return (
-									<CompTimeLayer
-										compositionId={props.composition.id}
-										id={layerId}
-										key={layerId}
-									/>
-								);
-							})}
-						</div>
-					</div>
-				</CompositionPropertyValuesProvider>
+					moveLayers={props.areaState.moveLayers}
+					panY={props.areaState.panY}
+				/>
 			</div>
 			<div
 				className={s("separator")}

--- a/src/composition/timeline/CompTimeLayerList.tsx
+++ b/src/composition/timeline/CompTimeLayerList.tsx
@@ -1,0 +1,148 @@
+import React, { useRef } from "react";
+import { getCompTimeTrackYPositions } from "~/composition/timeline/compTimeUtils";
+import { CompTimeLayer } from "~/composition/timeline/layer/CompTimeLayer";
+import { COMP_TIME_LAYER_HEIGHT } from "~/constants";
+import { cssVariables } from "~/cssVariables";
+import { useMemoActionState } from "~/hook/useActionState";
+import { CompositionPropertyValuesProvider } from "~/shared/composition/compositionRenderValues";
+import { connectActionState } from "~/state/stateUtils";
+import { hexToRGBAString } from "~/util/color/convertColor";
+import { compileStylesheetLabelled } from "~/util/stylesheets";
+
+const s = compileStylesheetLabelled(({ css }) => ({
+	layerWrapper: css`
+		flex-grow: 1;
+		overflow: hidden;
+		position: relative;
+	`,
+
+	previewBar: css`
+		position: absolute;
+		left: 0;
+		right: 0;
+		height: 2px;
+		background: ${cssVariables.primary700};
+		box-shadow: 0 0 8px 3px ${hexToRGBAString(cssVariables.primary500, 0.5)};
+		pointer-events: none;
+	`,
+}));
+
+interface OwnProps {
+	compositionId: string;
+	panY: number;
+	moveLayers: {
+		type: "above" | "below" | "invalid";
+		layerId: string;
+	} | null;
+}
+interface StateProps {
+	frameIndex: number;
+	layerIds: string[];
+	compositionWidth: number;
+	compositionHeight: number;
+}
+type Props = OwnProps & StateProps;
+
+const CompTimeLayerListComponent: React.FC<Props> = (props) => {
+	const {
+		layerIds,
+		compositionId,
+		frameIndex,
+		compositionWidth,
+		compositionHeight,
+		panY,
+		moveLayers,
+	} = props;
+
+	const layerWrapper = useRef<HTMLDivElement>(null);
+
+	const previewY = useMemoActionState(
+		({ compositionState }) => {
+			if (!moveLayers || moveLayers.type === "invalid") {
+				return null;
+			}
+
+			const { layerId, type } = moveLayers;
+			const yPosMap = getCompTimeTrackYPositions(compositionId, compositionState, panY);
+
+			if (!layerId) {
+				return 0;
+			}
+
+			if (type === "above") {
+				return yPosMap.layer[layerId];
+			}
+
+			const layer = compositionState.layers[layerId];
+
+			if (layer.collapsed) {
+				return yPosMap.layer[layerId] + COMP_TIME_LAYER_HEIGHT;
+			}
+
+			// Find last property
+			function crawl(propertyId: string): number {
+				const property = compositionState.properties[propertyId];
+				if (property.type === "property" || property.collapsed) {
+					return yPosMap.property[property.id] + COMP_TIME_LAYER_HEIGHT;
+				}
+				return crawl(property.properties[property.properties.length - 1]);
+			}
+
+			const { properties } = layer;
+			const value = crawl(properties[properties.length - 1]);
+			return value;
+		},
+		[moveLayers?.layerId, moveLayers?.type],
+	);
+
+	return (
+		<CompositionPropertyValuesProvider
+			compositionId={compositionId}
+			frameIndex={frameIndex}
+			containerWidth={compositionWidth}
+			containerHeight={compositionHeight}
+		>
+			<div
+				className={s("layerWrapper")}
+				ref={layerWrapper}
+				data-ct-composition-id={compositionId}
+			>
+				<div style={{ transform: `translateY(${-panY}px)` }}>
+					{layerIds.map((layerId) => {
+						return (
+							<CompTimeLayer
+								compositionId={props.compositionId}
+								id={layerId}
+								key={layerId}
+								layerWrapper={layerWrapper}
+							/>
+						);
+					})}
+				</div>
+				{typeof previewY === "number" && !isNaN(previewY) && (
+					<div className={s("previewBar")} style={{ top: previewY }} />
+				)}
+			</div>
+		</CompositionPropertyValuesProvider>
+	);
+};
+
+const mapState: MapActionState<StateProps, OwnProps> = (
+	{ compositionState },
+	{ compositionId },
+) => {
+	const {
+		frameIndex,
+		width: compositionWidth,
+		height: compositionHeight,
+		layers: layerIds,
+	} = compositionState.compositions[compositionId];
+	return {
+		layerIds,
+		frameIndex,
+		compositionHeight,
+		compositionWidth,
+	};
+};
+
+export const CompTimeLayerList = connectActionState(mapState)(CompTimeLayerListComponent);

--- a/src/composition/timeline/compTimeAreaReducer.ts
+++ b/src/composition/timeline/compTimeAreaReducer.ts
@@ -9,6 +9,7 @@ export interface CompTimeAreaState {
 	trackDragSelectRect: Rect | null;
 	layerIndexShift: number;
 	layerLengthShift: [number, number];
+	moveLayers: null | { layerId: string; type: "above" | "below" | "invalid" };
 }
 
 export const initialCompTimeAreaState: CompTimeAreaState = {
@@ -20,6 +21,7 @@ export const initialCompTimeAreaState: CompTimeAreaState = {
 	trackDragSelectRect: null,
 	layerIndexShift: 0,
 	layerLengthShift: [0, 0],
+	moveLayers: null,
 };
 
 export const compTimeAreaActions = {

--- a/src/composition/timeline/compTimeHandlers.ts
+++ b/src/composition/timeline/compTimeHandlers.ts
@@ -514,18 +514,16 @@ export const compTimeHandlers = {
 					return;
 				}
 
-				const { moveLayers: moveLayersBelow } = getAreaActionState<
-					AreaType.CompositionTimeline
-				>(areaId);
+				const { moveLayers } = getAreaActionState<AreaType.CompositionTimeline>(areaId);
 
-				if (moveLayersBelow) {
-					// Clear `moveLayersBelow`
+				if (moveLayers) {
+					// Clear `moveLayers`
 					params.dispatchToAreaState(
 						areaId,
 						compTimeAreaActions.setFields({ moveLayers: null }),
 					);
 
-					if (moveLayersBelow.type === "invalid") {
+					if (moveLayers.type === "invalid") {
 						params.submitAction("Add layer to selection");
 						return;
 					}
@@ -535,7 +533,7 @@ export const compTimeHandlers = {
 					params.dispatch(
 						compositionActions.moveLayers(
 							compositionId,
-							moveLayersBelow as { layerId: string; type: "above" | "below" },
+							moveLayers as { layerId: string; type: "above" | "below" },
 							compositionSelectionState,
 						),
 					);

--- a/src/composition/timeline/compTimeHandlers.ts
+++ b/src/composition/timeline/compTimeHandlers.ts
@@ -24,6 +24,7 @@ import {
 	requestAction,
 	RequestActionCallback,
 	RequestActionParams,
+	ShouldAddToStackFn,
 } from "~/listener/requestAction";
 import { createLayerGraph } from "~/nodeEditor/graph/createLayerGraph";
 import { nodeEditorActions } from "~/nodeEditor/nodeEditorActions";
@@ -475,8 +476,21 @@ export const compTimeHandlers = {
 			);
 		};
 
+		const didLayerOrderChange: ShouldAddToStackFn = (a, b) => {
+			const layersA = a.compositionState.compositions[compositionId].layers;
+			const layersB = b.compositionState.compositions[compositionId].layers;
+
+			for (let i = 0; i < layersA.length; i += 1) {
+				if (layersA[i] !== layersB[i]) {
+					return true;
+				}
+			}
+
+			return false;
+		};
+
 		mouseDownMoveAction(e, {
-			shouldAddToStack: didCompSelectionChange(compositionId),
+			shouldAddToStack: [didCompSelectionChange(compositionId), didLayerOrderChange],
 			beforeMove: (params) => {
 				if (!additiveSelection && willBeSelected) {
 					// The selection is non-additive and the layer will be selected.

--- a/src/composition/timeline/layer/CompTimeLayer.tsx
+++ b/src/composition/timeline/layer/CompTimeLayer.tsx
@@ -19,6 +19,7 @@ const s = compileStylesheetLabelled(styles);
 interface OwnProps {
 	id: string;
 	compositionId: string;
+	layerWrapper: React.RefObject<HTMLDivElement>;
 }
 interface StateProps {
 	layer: CompositionLayer;
@@ -33,7 +34,7 @@ const CompTimeLayerComponent: React.FC<Props> = (props) => {
 	} = props;
 
 	return (
-		<div data-ct-layer-id={props.id}>
+		<div data-ct-layer-id={props.id} style={{ position: "relative" }}>
 			<div
 				className={s("container")}
 				onMouseDown={separateLeftRightMouse({
@@ -52,7 +53,7 @@ const CompTimeLayerComponent: React.FC<Props> = (props) => {
 						});
 					}}
 				/>
-				<CompTimeLayerName layerId={props.id} />
+				<CompTimeLayerName layerId={props.id} layerWrapper={props.layerWrapper} />
 				<div
 					title={layer.graphId ? "Delete Layer Graph" : "Create Layer Graph"}
 					className={s("graph", { active: !!layer.graphId })}

--- a/src/composition/timeline/layer/CompTimeLayerName.tsx
+++ b/src/composition/timeline/layer/CompTimeLayerName.tsx
@@ -1,4 +1,5 @@
-import React, { useRef, useState } from "react";
+import React, { useContext, useRef, useState } from "react";
+import { AreaIdContext } from "~/area/util/AreaIdContext";
 import { compositionActions } from "~/composition/state/compositionReducer";
 import { compTimeHandlers } from "~/composition/timeline/compTimeHandlers";
 import { reduceLayerPropertiesAndGroups } from "~/composition/timeline/compTimeUtils";
@@ -68,6 +69,7 @@ const s = compileStylesheetLabelled(({ css }) => ({
 
 interface OwnProps {
 	layerId: string;
+	layerWrapper: React.RefObject<HTMLDivElement>;
 }
 interface StateProps {
 	name: string;
@@ -83,6 +85,8 @@ const CompTimeLayerNameComponent: React.FC<Props> = (props) => {
 
 	const [renaming, setRenaming] = useState(false);
 	const paramsRef = useRef<RequestActionParams | null>(null);
+
+	const areaId = useContext(AreaIdContext);
 
 	const onDoubleClick = () => {
 		requestAction({ history: true }, (params) => {
@@ -151,8 +155,10 @@ const CompTimeLayerNameComponent: React.FC<Props> = (props) => {
 					left: (e) =>
 						compTimeHandlers.onLayerNameMouseDown(
 							e,
+							areaId,
 							props.compositionId,
 							props.layerId,
+							props.layerWrapper,
 						),
 				})}
 				onDoubleClick={onDoubleClick}

--- a/src/composition/timeline/track/trackHandlers.ts
+++ b/src/composition/timeline/track/trackHandlers.ts
@@ -1,7 +1,7 @@
 import { areaActions } from "~/area/state/areaActions";
 import { CompositionProperty } from "~/composition/compositionTypes";
 import { compositionActions } from "~/composition/state/compositionReducer";
-import { compositionSelectionActions } from "~/composition/state/compositionSelectionReducer";
+import { compSelectionActions } from "~/composition/state/compositionSelectionReducer";
 import { compTimeAreaActions } from "~/composition/timeline/compTimeAreaReducer";
 import {
 	getCompTimeTrackYPositions,
@@ -134,7 +134,7 @@ const actions = {
 
 				if (additiveSelection) {
 					params.dispatch(
-						compositionSelectionActions.toggleLayerSelection(composition.id, layerId),
+						compSelectionActions.toggleLayerSelection(composition.id, layerId),
 					);
 
 					// If the layer is being deselected, we clear the selection of all timelines
@@ -153,10 +153,10 @@ const actions = {
 					// in the composition
 					params.dispatch(timelineIds.map((id) => timelineActions.clearSelection(id)));
 					params.dispatch(
-						compositionSelectionActions.toggleLayerSelection(composition.id, layerId),
+						compSelectionActions.toggleLayerSelection(composition.id, layerId),
 					);
 					params.dispatch(
-						compositionSelectionActions.removeLayersFromSelection(
+						compSelectionActions.removeLayersFromSelection(
 							composition.id,
 							composition.layers.filter((id) => id !== layerId),
 						),
@@ -239,19 +239,16 @@ const actions = {
 					// natural to deselect and resize other layers in the same action.
 					if (!compositionSelection.layers[layerId]) {
 						params.dispatch(
-							compositionSelectionActions.toggleLayerSelection(
-								composition.id,
-								layerId,
-							),
+							compSelectionActions.toggleLayerSelection(composition.id, layerId),
 						);
 					}
 				} else if (!compositionSelection.layers[layerId]) {
 					params.dispatch(timelineIds.map((id) => timelineActions.clearSelection(id)));
 					params.dispatch(
-						compositionSelectionActions.toggleLayerSelection(composition.id, layerId),
+						compSelectionActions.toggleLayerSelection(composition.id, layerId),
 					);
 					params.dispatch(
-						compositionSelectionActions.removeLayersFromSelection(
+						compSelectionActions.removeLayersFromSelection(
 							composition.id,
 							composition.layers.filter((id) => id !== layerId),
 						),
@@ -466,9 +463,7 @@ export const trackHandlers = {
 				).map((timelineId) => timelineState[timelineId]);
 
 				if (!hasMoved) {
-					params.dispatch(
-						compositionSelectionActions.clearCompositionSelection(composition.id),
-					);
+					params.dispatch(compSelectionActions.clearCompositionSelection(composition.id));
 					params.dispatch(
 						timelines.map((timeline) => timelineActions.clearSelection(timeline.id)),
 					);
@@ -522,9 +517,7 @@ export const trackHandlers = {
 					params.dispatch(
 						timelines.map((timeline) => timelineActions.clearSelection(timeline.id)),
 					);
-					params.dispatch(
-						compositionSelectionActions.clearCompositionSelection(composition.id),
-					);
+					params.dispatch(compSelectionActions.clearCompositionSelection(composition.id));
 				}
 
 				// Add keyframes to selection
@@ -540,7 +533,7 @@ export const trackHandlers = {
 				);
 				params.dispatch(
 					affectedPropertyIds.map((propertyId) => {
-						return compositionSelectionActions.addPropertyToSelection(
+						return compSelectionActions.addPropertyToSelection(
 							options.compositionId,
 							propertyId,
 						);
@@ -560,7 +553,7 @@ export const trackHandlers = {
 				];
 				params.dispatch(
 					affectedLayerIds.map((layerId) => {
-						return compositionSelectionActions.addLayerToSelection(
+						return compSelectionActions.addLayerToSelection(
 							options.compositionId,
 							layerId,
 						);

--- a/src/hook/useActionState.ts
+++ b/src/hook/useActionState.ts
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import { shallowEqual, useSelector } from "react-redux";
 import { getActionStateFromApplicationState } from "~/state/stateUtils";
 import { store } from "~/state/store";
@@ -14,6 +14,16 @@ export const useActionState = <T>(selector: Selector<T>, { shallow = true } = {}
 		shallow ? shallowEqual : undefined,
 	);
 	return result;
+};
+
+export const useMemoActionState = <T>(selector: Selector<T>, deps: React.DependencyList): T => {
+	const selectorRef = useRef(selector);
+	selectorRef.current = selector;
+
+	return useMemo(() => {
+		const actionState = getActionStateFromApplicationState(store.getState());
+		return selectorRef.current(actionState);
+	}, deps);
 };
 
 export const useActionStateEffect = (

--- a/src/listener/requestAction.ts
+++ b/src/listener/requestAction.ts
@@ -16,7 +16,7 @@ export const requestActionCancellation = (): void => {
 	_cancelAction?.();
 };
 
-interface Options {
+export interface RequestActionOptions {
 	history?: boolean;
 	shouldAddToStack?: (prevState: ActionState, nextState: ActionState) => boolean;
 }
@@ -37,7 +37,7 @@ export interface RequestActionCallback {
 }
 
 const performRequestedAction = (
-	{ history = false, shouldAddToStack }: Options,
+	{ history = false, shouldAddToStack }: RequestActionOptions,
 	callback: RequestActionCallback,
 ): void => {
 	const actionId = (++_n).toString();
@@ -164,7 +164,10 @@ const performRequestedAction = (
 	});
 };
 
-export const requestAction = (options: Options, callback: RequestActionCallback): void => {
+export const requestAction = (
+	options: RequestActionOptions,
+	callback: RequestActionCallback,
+): void => {
 	if (!getActionId()) {
 		performRequestedAction(options, callback);
 		return;

--- a/src/project/compEligibleTargets.ts
+++ b/src/project/compEligibleTargets.ts
@@ -1,3 +1,4 @@
+import { Composition } from "~/composition/compositionTypes";
 import { getActionState } from "~/state/stateUtils";
 
 type Target = {
@@ -11,6 +12,28 @@ interface TargetGroup {
 	targets: Target[];
 }
 
+export const getLayerTargetsWithinComp = (
+	composition: Composition,
+	layerWrapper: HTMLDivElement,
+): Target[] => {
+	const targets: Target[] = [];
+
+	const layerEls = layerWrapper.querySelectorAll("[data-ct-layer-id]");
+
+	for (let j = 0; j < layerEls.length; j += 1) {
+		const layerEl = layerEls[j];
+		const layerId = layerEl.getAttribute("data-ct-layer-id")!;
+		const index = composition.layers.indexOf(layerId);
+
+		targets.push({
+			rect: layerEl.getBoundingClientRect(),
+			index: index,
+		});
+	}
+
+	return targets;
+};
+
 export const getCompEligibleTargets = () => {
 	const compEls = document.querySelectorAll("[data-ct-composition-id]");
 
@@ -19,30 +42,17 @@ export const getCompEligibleTargets = () => {
 	const compositionState = getActionState().compositionState;
 
 	for (let i = 0; i < compEls.length; i += 1) {
-		const compEl = compEls[i];
-		const compositionId = compEl.getAttribute("data-ct-composition-id")!;
+		const layerWrapper = compEls[i] as HTMLDivElement;
+		const compositionId = layerWrapper.getAttribute("data-ct-composition-id")!;
 
 		const composition = compositionState.compositions[compositionId];
 
 		const group: TargetGroup = {
 			compositionId,
-			rect: compEl.getBoundingClientRect(),
-			targets: [],
+			rect: layerWrapper.getBoundingClientRect(),
+			targets: getLayerTargetsWithinComp(composition, layerWrapper),
 		};
 		groups.push(group);
-
-		const layerEls = compEl.querySelectorAll("[data-ct-layer-id]");
-
-		for (let j = 0; j < layerEls.length; j += 1) {
-			const layerEl = layerEls[j];
-			const layerId = layerEl.getAttribute("data-ct-layer-id")!;
-			const index = composition.layers.indexOf(layerId);
-
-			group.targets.push({
-				rect: layerEl.getBoundingClientRect(),
-				index: index,
-			});
-		}
 	}
 
 	return groups;

--- a/src/project/dragComp/ProjectDragCompPreview.tsx
+++ b/src/project/dragComp/ProjectDragCompPreview.tsx
@@ -94,7 +94,7 @@ export const ProjectDragCompPreview: React.FC = () => {
 		}
 
 		// Below last item
-		const yMax = Math.max(...targets.map(({ rect }) => rect.top + rect.height));
+		const yMax = Math.max(rect.top, ...targets.map(({ rect }) => rect.top + rect.height));
 		renderCoords = {
 			left: rect.left,
 			width: rect.width,

--- a/src/util/action/mouseDownMoveAction.ts
+++ b/src/util/action/mouseDownMoveAction.ts
@@ -1,4 +1,3 @@
-import { addListener } from "~/listener/addListener";
 import { requestAction, RequestActionParams } from "~/listener/requestAction";
 import { getDistance } from "~/util/math";
 
@@ -80,7 +79,7 @@ export const mouseDownMoveAction = (
 			options.mouseMove(params, { initialMousePosition, mousePosition, moveVector });
 		});
 
-		addListener.once("mouseup", () => {
+		params.addListener.once("mouseup", () => {
 			options.mouseUp(params, hasMoved);
 		});
 	});

--- a/src/util/action/mouseDownMoveAction.ts
+++ b/src/util/action/mouseDownMoveAction.ts
@@ -1,4 +1,4 @@
-import { requestAction, RequestActionParams } from "~/listener/requestAction";
+import { requestAction, RequestActionParams, ShouldAddToStackFn } from "~/listener/requestAction";
 import { getDistance } from "~/util/math";
 
 interface MousePosition {
@@ -21,7 +21,7 @@ interface Options {
 	translateX?: (value: number) => number;
 	translateY?: (value: number) => number;
 	moveTreshold?: number;
-	shouldAddToStack?: (prevState: ActionState, nextState: ActionState) => boolean;
+	shouldAddToStack?: ShouldAddToStackFn | ShouldAddToStackFn[];
 }
 
 export const mouseDownMoveAction = (
@@ -49,7 +49,7 @@ export const mouseDownMoveAction = (
 		translated: translate(initialGlobalMousePosition),
 	};
 
-	requestAction({ history: true }, (params) => {
+	requestAction({ history: true, shouldAddToStack: options.shouldAddToStack }, (params) => {
 		options.beforeMove(params);
 
 		let hasMoved = false;


### PR DESCRIPTION
Closes #45

# Changes

## Add `AreaIdContext`

Each area now provides it area id via `AreaIdContext`. This allows us to avoid prop drilling.


## Move Layers

Added `moveLayers` to `compositionActions`. It accepts `compositionId`, `moveLayers` and a composition selection state.

`moveLayers` looks like so:

```tsx
{ type: "above" | "below"; layerId: string; }
```

It inserts the selected layer above/below the target `layerId`. The `layerId` may not be a selected layer.

For preview purposes, added `moveLayers` to `CompTimeAreaState`. It looks like so:

```tsx
export interface CompTimeAreaState {
	// ...

	moveLayers: null | { layerId: string; type: "above" | "below" | "invalid" };
}
```

If the type is `invalid`, no action would be taken on mouse up (aside from possible selection modification).
