### PR TITLE
Drag Layers around in Composition Workspace

### DIFF
--- a/src/composition/timeline/compTimeHandlers.ts
+++ b/src/composition/timeline/compTimeHandlers.ts
@@ -269,10 +269,13 @@ export const compTimeHandlers = {
 	},
 
 	onPropertyKeyframeIconMouseDown: (
+		e: React.MouseEvent,
 		compositionId: string,
 		propertyId: string,
 		timelineId: string,
 	): void => {
+		e.stopPropagation();
+
 		const { compositionState, timelines, timelineSelection } = getActionState();
 		const composition = compositionState.compositions[compositionId];
 		const property = compositionState.properties[propertyId] as CompositionProperty;

--- a/src/composition/timeline/property/CompTimeProperty.tsx
+++ b/src/composition/timeline/property/CompTimeProperty.tsx
@@ -98,8 +98,9 @@ const CompTimeLayerPropertyComponent: React.FC<Props> = (props) => {
 				<div
 					className={s("timelineIcon", { active: !!property.timelineId })}
 					onMouseDown={separateLeftRightMouse({
-						left: () =>
+						left: (e) =>
 							compTimeHandlers.onPropertyKeyframeIconMouseDown(
+								e,
 								props.compositionId,
 								property.id,
 								property.timelineId,

--- a/src/composition/workspace/CompWorkspace.tsx
+++ b/src/composition/workspace/CompWorkspace.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from "react";
+import React, { useEffect, useMemo, useRef } from "react";
 import { NumberInput } from "~/components/common/NumberInput";
 import { CompositionPlaybackProvider } from "~/composition/hook/useCompositionPlayback";
 import { compositionActions } from "~/composition/state/compositionReducer";
@@ -122,6 +122,14 @@ const CompositionWorkspaceComponent: React.FC<Props> = (props) => {
 		};
 	}, [containerRef.current]);
 
+	const { left, top, width, height } = props;
+	const viewport = useMemo<Rect>(() => ({ left, top, width, height }), [
+		left,
+		top,
+		width,
+		height,
+	]);
+
 	return (
 		<>
 			<div className={s("header")}></div>
@@ -129,6 +137,7 @@ const CompositionWorkspaceComponent: React.FC<Props> = (props) => {
 				className={s("container")}
 				ref={containerRef}
 				onMouseDown={separateLeftRightMouse({
+					left: () => compWorkspaceHandlers.onMouseDownOut(composition.id),
 					middle: (e) => compWorkspaceHandlers.onPanStart(props.areaId, e),
 				})}
 			>
@@ -152,7 +161,7 @@ const CompositionWorkspaceComponent: React.FC<Props> = (props) => {
 							<CompositionPlaybackProvider
 								compositionId={props.areaState.compositionId}
 							>
-								<CompWorkspaceViewportContext.Provider value={{ scale }}>
+								<CompWorkspaceViewportContext.Provider value={{ scale, viewport }}>
 									<CompWorkspaceCompChildren
 										compositionId={composition.id}
 										containerHeight={composition.height}

--- a/src/composition/workspace/CompWorkspaceViewportContext.tsx
+++ b/src/composition/workspace/CompWorkspaceViewportContext.tsx
@@ -1,3 +1,6 @@
 import React from "react";
 
-export const CompWorkspaceViewportContext = React.createContext<{ scale: number }>({ scale: 1 });
+export const CompWorkspaceViewportContext = React.createContext<{ scale: number; viewport: Rect }>({
+	scale: 1,
+	viewport: { top: 0, left: 0, width: 0, height: 0 },
+});

--- a/src/composition/workspace/compWorkspaceHandlers.ts
+++ b/src/composition/workspace/compWorkspaceHandlers.ts
@@ -1,8 +1,312 @@
+import { CompositionProperty } from "~/composition/compositionTypes";
+import { compositionActions } from "~/composition/state/compositionReducer";
+import { compSelectionActions } from "~/composition/state/compositionSelectionReducer";
+import {
+	getTimelineIdsReferencedByComposition,
+	reduceCompProperties,
+	reduceLayerPropertiesAndGroups,
+} from "~/composition/timeline/compTimeUtils";
+import {
+	didCompSelectionChange,
+	getCompSelectionFromState,
+} from "~/composition/util/compSelectionUtils";
 import { compositionWorkspaceAreaActions } from "~/composition/workspace/compWorkspaceAreaReducer";
 import { AreaType } from "~/constants";
+import { isKeyDown } from "~/listener/keyboard";
+import { requestAction, RequestActionParams } from "~/listener/requestAction";
+import { transformGlobalToNodeEditorPosition } from "~/nodeEditor/nodeEditorUtils";
+import { getCompositionRenderValues } from "~/shared/composition/compositionRenderValues";
 import { createViewportWheelHandlers } from "~/shared/viewport/viewportWheelHandlers";
+import { getActionState, getAreaActionState } from "~/state/stateUtils";
+import { timelineActions } from "~/timeline/timelineActions";
+import { getTimelineValueAtIndex } from "~/timeline/timelineUtils";
+import { PropertyName } from "~/types";
+import { mouseDownMoveAction } from "~/util/action/mouseDownMoveAction";
 
-export const compWorkspaceHandlers = createViewportWheelHandlers(AreaType.NodeEditor, {
-	setPan: compositionWorkspaceAreaActions.setPan,
-	setScale: compositionWorkspaceAreaActions.setScale,
-});
+export const compWorkspaceHandlers = {
+	onLayerRectMouseDown: (
+		e: React.MouseEvent,
+		layerId: string,
+		areaId: string,
+		viewport: Rect,
+	) => {
+		const { pan, scale } = getAreaActionState<AreaType.CompositionWorkspace>(areaId);
+		const actionState = getActionState();
+		const {
+			compositionState,
+			compositionSelectionState,
+			timelines,
+			timelineSelection,
+		} = actionState;
+
+		const layer = compositionState.layers[layerId];
+		const { compositionId } = layer;
+
+		const composition = compositionState.compositions[compositionId];
+		const compositionSelection = getCompSelectionFromState(
+			compositionId,
+			compositionSelectionState,
+		);
+
+		const willBeSelected = !compositionSelection.layers[layerId];
+		const additiveSelection = isKeyDown("Shift") || isKeyDown("Command");
+
+		const addLayerToSelection = (params: RequestActionParams) => {
+			params.dispatch(compSelectionActions.addLayerToSelection(compositionId, layerId));
+		};
+
+		const removeLayerFromSelection = (params: RequestActionParams) => {
+			params.dispatch(
+				compSelectionActions.removeLayersFromSelection(compositionId, [layerId]),
+			);
+		};
+
+		const clearCompositionSelection = (params: RequestActionParams) => {
+			// Clear composition selection
+			params.dispatch(compSelectionActions.clearCompositionSelection(compositionId));
+
+			// Clear timeline selection of selected properties
+			const timelineIds = getTimelineIdsReferencedByComposition(
+				compositionId,
+				compositionState,
+			);
+			params.dispatch(
+				timelineIds.map((timelineId) => timelineActions.clearSelection(timelineId)),
+			);
+		};
+
+		const deselectLayerProperties = (params: RequestActionParams) => {
+			// Deselect all properties and timeline keyframes
+			const propertyIds = reduceLayerPropertiesAndGroups<string[]>(
+				layerId,
+				compositionState,
+				(acc, property) => {
+					acc.push(property.id);
+					return acc;
+				},
+				[],
+			).filter((propertyId) => compositionSelection.properties[propertyId]);
+
+			const timelineIds = propertyIds.reduce<string[]>((acc, propertyId) => {
+				const property = compositionState.properties[propertyId];
+
+				if (property.type === "property" && property.timelineId) {
+					acc.push(property.timelineId);
+				}
+
+				return acc;
+			}, []);
+
+			params.dispatch(
+				compSelectionActions.removePropertiesFromSelection(compositionId, propertyIds),
+			);
+			params.dispatch(
+				timelineIds.map((timelineId) => timelineActions.clearSelection(timelineId)),
+			);
+		};
+
+		const layerInitialPositions: { [layerId: string]: Vec2 } = {};
+		const layerPositionPropertyIds: { [layerId: string]: [string, string] } = {};
+
+		const doAxis = (name: PropertyName, axis: "x" | "y", i: 0 | 1) => (
+			property: CompositionProperty,
+		) => {
+			if (property.name === name) {
+				const timelineId = property.timelineId;
+				const layer = compositionState.layers[property.layerId];
+
+				const value = timelineId
+					? getTimelineValueAtIndex({
+							frameIndex: composition.frameIndex,
+							layerIndex: layer.index,
+							timeline: timelines[timelineId],
+							selection: timelineSelection[timelineId],
+					  })
+					: property.value;
+
+				if (!layerInitialPositions[property.layerId]) {
+					layerInitialPositions[property.layerId] = Vec2.new(0, 0);
+				}
+
+				layerInitialPositions[property.layerId][axis] = value;
+
+				if (!layerPositionPropertyIds[property.layerId]) {
+					layerPositionPropertyIds[property.layerId] = ["", ""];
+				}
+				layerPositionPropertyIds[property.layerId][i] = property.id;
+			}
+		};
+		const doX = doAxis(PropertyName.PositionX, "x", 0);
+		const doY = doAxis(PropertyName.PositionY, "y", 1);
+
+		reduceCompProperties(
+			compositionId,
+			compositionState,
+			(acc, property) => {
+				doX(property);
+				doY(property);
+				return acc;
+			},
+			null,
+		);
+
+		let didMove = false;
+
+		const renderValues = getCompositionRenderValues(
+			actionState,
+			compositionId,
+			composition.frameIndex,
+			{
+				width: composition.width,
+				height: composition.height,
+			},
+			{
+				recursive: false,
+			},
+		);
+
+		mouseDownMoveAction(e, {
+			shouldAddToStack: [didCompSelectionChange(compositionId), () => didMove],
+			translate: (vec) => transformGlobalToNodeEditorPosition(vec, viewport, scale, pan),
+			beforeMove: (params) => {
+				if (!additiveSelection && willBeSelected) {
+					// The selection is non-additive and the layer will be selected.
+					//
+					// Clear the composition selection and then add the layer to selection.
+					clearCompositionSelection(params);
+					addLayerToSelection(params);
+					return;
+				}
+
+				if (additiveSelection && !willBeSelected) {
+					// The selection is additive and the layer will NOT be selected.
+					//
+					// Deselect the layer and its properties.
+					deselectLayerProperties(params);
+					removeLayerFromSelection(params);
+				} else {
+					addLayerToSelection(params);
+				}
+			},
+			mouseMove: (params, { moveVector: _moveVector }) => {
+				// Layer was deselected, do not move selected layers.
+				if (additiveSelection && !willBeSelected) {
+					return;
+				}
+
+				if (!didMove) {
+					didMove = true;
+				}
+
+				const { compositionState, compositionSelectionState } = getActionState();
+				const compositionSelection = getCompSelectionFromState(
+					compositionId,
+					compositionSelectionState,
+				);
+
+				const toDispatch: any[] = [];
+
+				const layerIds = composition.layers.filter(
+					(layerId) => compositionSelection.layers[layerId],
+				);
+
+				for (const layerId of layerIds) {
+					const layer = compositionState.layers[layerId];
+					let moveVector = _moveVector.translated.copy();
+
+					if (layer.parentLayerId) {
+						// Check if any layer in the parent chain is selected, if so skip
+						function hasSelectedParent(parentLayerId: string): boolean {
+							if (compositionSelection.layers[parentLayerId]) {
+								return true;
+							}
+
+							const layer = compositionState.layers[parentLayerId];
+							if (!layer.parentLayerId) {
+								return false;
+							}
+
+							return hasSelectedParent(layer.parentLayerId);
+						}
+
+						if (hasSelectedParent(layer.parentLayerId)) {
+							continue;
+						}
+
+						const transform = renderValues.transforms[layer.parentLayerId];
+						moveVector = moveVector
+							.scale(1 / transform.scale)
+							.rotate(-transform.rotation);
+					}
+
+					for (let i = 0; i < 2; i += 1) {
+						const axis = i === 0 ? "x" : "y";
+
+						const propertyId = layerPositionPropertyIds[layerId][i];
+						const initialValue = layerInitialPositions[layerId][axis];
+
+						const property = compositionState.properties[
+							propertyId
+						] as CompositionProperty;
+
+						if (!property.timelineId) {
+							toDispatch.push(
+								compositionActions.setPropertyValue(
+									propertyId,
+									initialValue + moveVector[axis],
+								),
+							);
+							continue;
+						}
+					}
+				}
+
+				params.dispatch(toDispatch);
+			},
+			mouseUp: (params) => {
+				if (additiveSelection && !willBeSelected) {
+					params.submitAction("Remove layer from selection");
+					return;
+				}
+
+				if (didMove) {
+					params.submitAction("Move selected layers");
+					return;
+				}
+
+				if (!additiveSelection) {
+					clearCompositionSelection(params);
+					addLayerToSelection(params);
+				}
+
+				params.submitAction("Add layer to selection");
+			},
+		});
+	},
+
+	onMouseDownOut: (compositionId: string): void => {
+		requestAction(
+			{ history: true, shouldAddToStack: didCompSelectionChange(compositionId) },
+			(params) => {
+				const { compositionState } = getActionState();
+
+				params.dispatch(compSelectionActions.clearCompositionSelection(compositionId));
+
+				const timelineIds = getTimelineIdsReferencedByComposition(
+					compositionId,
+					compositionState,
+				);
+				params.dispatch(
+					timelineIds.map((timelineId) => timelineActions.clearSelection(timelineId)),
+				);
+
+				params.submitAction("Clear composition selection");
+			},
+		);
+	},
+
+	...createViewportWheelHandlers(AreaType.NodeEditor, {
+		setPan: compositionWorkspaceAreaActions.setPan,
+		setScale: compositionWorkspaceAreaActions.setScale,
+	}),
+};

--- a/src/composition/workspace/layers/CompWorkspaceCompChildren.tsx
+++ b/src/composition/workspace/layers/CompWorkspaceCompChildren.tsx
@@ -19,8 +19,9 @@ interface StateProps {
 type Props = OwnProps & StateProps;
 
 const CompWorkspaceCompChildrenComponent: React.FC<Props> = (props) => {
-	const { layerIds, layerTypes } = props;
+	const { layerIds: _layerIds, layerTypes } = props;
 
+	const layerIds = [..._layerIds];
 	const layers: React.ReactNode[] = [];
 
 	const getLayerContent = (i: number) => {
@@ -58,7 +59,7 @@ const CompWorkspaceCompChildrenComponent: React.FC<Props> = (props) => {
 		);
 	};
 
-	for (let i = layerIds.length - 1; i >= 0; i -= 1) {
+	for (let i = 0; i < layerIds.length; i += 1) {
 		layers.push(getLayerContent(i));
 	}
 

--- a/src/composition/workspace/layers/CompWorkspaceLayerGuides.tsx
+++ b/src/composition/workspace/layers/CompWorkspaceLayerGuides.tsx
@@ -1,15 +1,187 @@
-import React from "react";
+import React, { useContext } from "react";
+import { AreaIdContext } from "~/area/util/AreaIdContext";
 import { CompositionLayer } from "~/composition/compositionTypes";
 import { useLayerNameToProperty } from "~/composition/hook/useLayerNameToProperty";
 import { getCompSelectionFromState } from "~/composition/util/compSelectionUtils";
+import { compWorkspaceHandlers } from "~/composition/workspace/compWorkspaceHandlers";
 import { CompWorkspaceLayerBaseProps } from "~/composition/workspace/compWorkspaceTypes";
 import { CompWorkspaceViewportContext } from "~/composition/workspace/CompWorkspaceViewportContext";
+import { getLayerTransformStyle } from "~/composition/workspace/layers/layerTransformStyle";
 import { useWorkspaceLayerShouldRender } from "~/composition/workspace/useWorkspaceLayerShouldRender";
 import { connectActionState } from "~/state/stateUtils";
 import { AffineTransform, LayerType } from "~/types";
 import { rotateVec2CCW } from "~/util/math";
+import { compileStylesheetLabelled } from "~/util/stylesheets";
+
+const color = "rgb(89 142 243)";
+
+const s = compileStylesheetLabelled(({ css }) => ({
+	interactionLayer: css`
+		stroke: ${color};
+		position: absolute;
+		left: 0;
+		top: 0;
+		fill: transparent;
+		opacity: 0;
+
+		&:hover {
+			opacity: 1;
+		}
+	`,
+}));
 
 export const AdditionalTransformContext = React.createContext<AffineTransform[]>([]);
+
+interface GuideProps {
+	positionX: number;
+	positionY: number;
+	anchorX: number;
+	anchorY: number;
+	rotation: number;
+	scale: number;
+	width: number;
+	height: number;
+	transform: AffineTransform;
+}
+
+const Guides: React.FC<GuideProps> = (props) => {
+	const {
+		positionX,
+		positionY,
+		anchorX,
+		anchorY,
+		rotation,
+		scale,
+		width,
+		height,
+		transform,
+	} = props;
+
+	const anchorShadowColor = "white";
+
+	const W = 9 / scale;
+	const R = 5 / scale;
+	const S = 1.4 / scale;
+	const A = 3 / scale;
+	const SW = 1 / scale;
+	const SOFF = 1 / scale;
+
+	return (
+		<>
+			{[
+				[0, 0],
+				[0, 1],
+				[1, 0],
+				[1, 1],
+			].map(([x, y], i) => {
+				const pt = transform;
+				const pos = Vec2.new(positionX + width * x, positionY + height * y)
+					.sub(Vec2.new(anchorX, anchorY))
+					.apply((pos) => rotateVec2CCW(pos, pt.rotation, pt.translate))
+					.scale(pt.scale, pt.translate)
+					.sub(Vec2.new(W / 2, W / 2));
+
+				return (
+					<g key={i}>
+						<rect
+							width={W}
+							height={W}
+							x={pos.x + SOFF}
+							y={pos.y + SOFF}
+							style={{ fill: "black" }}
+						/>
+						<rect width={W} height={W} x={pos.x} y={pos.y} style={{ fill: color }} />
+					</g>
+				);
+			})}
+			<ellipse
+				cx={positionX}
+				cy={positionY}
+				rx={R}
+				ry={R}
+				style={{ stroke: anchorShadowColor, strokeWidth: S + SW * 2, fill: "transparent" }}
+			/>
+			<g
+				style={{
+					transformOrigin: `${positionX}px ${positionY}px`,
+					transform: `rotate(${rotation}rad)`,
+				}}
+			>
+				<line
+					y1={positionY - R}
+					y2={positionY - (R + A + SW)}
+					x1={positionX}
+					x2={positionX}
+					stroke={anchorShadowColor}
+					strokeWidth={S + SW * 2}
+				/>
+				<line
+					y1={positionY + R}
+					y2={positionY + (R + A + SW)}
+					x1={positionX}
+					x2={positionX}
+					stroke={anchorShadowColor}
+					strokeWidth={S + SW * 2}
+				/>
+				<line
+					y1={positionY}
+					y2={positionY}
+					x1={positionX - R}
+					x2={positionX - (R + A + SW)}
+					stroke={anchorShadowColor}
+					strokeWidth={S + SW * 2}
+				/>
+				<line
+					y1={positionY}
+					y2={positionY}
+					x1={positionX + R}
+					x2={positionX + (R + A + SW)}
+					stroke={anchorShadowColor}
+					strokeWidth={S + SW * 2}
+				/>
+				<line
+					y1={positionY - R}
+					y2={positionY - (R + A)}
+					x1={positionX}
+					x2={positionX}
+					stroke={color}
+					strokeWidth={S}
+				/>
+				<line
+					y1={positionY + R}
+					y2={positionY + (R + A)}
+					x1={positionX}
+					x2={positionX}
+					stroke={color}
+					strokeWidth={S}
+				/>
+				<line
+					y1={positionY}
+					y2={positionY}
+					x1={positionX - R}
+					x2={positionX - (R + A)}
+					stroke={color}
+					strokeWidth={S}
+				/>
+				<line
+					y1={positionY}
+					y2={positionY}
+					x1={positionX + R}
+					x2={positionX + (R + A)}
+					stroke={color}
+					strokeWidth={S}
+				/>
+			</g>
+			<ellipse
+				cx={positionX}
+				cy={positionY}
+				rx={R}
+				ry={R}
+				style={{ stroke: color, strokeWidth: S, fill: "transparent" }}
+			/>
+		</>
+	);
+};
 
 type OwnProps = CompWorkspaceLayerBaseProps;
 interface StateProps {
@@ -27,11 +199,11 @@ const CompWorkspaceLayerGuidesComponent: React.FC<Props> = (props) => {
 
 	const { scale } = React.useContext(CompWorkspaceViewportContext);
 
-	if (!shouldRender || !props.selected) {
+	if (!shouldRender) {
 		return null;
 	}
 
-	let { PositionX, PositionY, Rotation, AnchorX, AnchorY } = nameToProperty;
+	let { PositionX, PositionY, Rotation, AnchorX, AnchorY, Scale } = nameToProperty;
 
 	let width: number;
 	let height: number;
@@ -58,129 +230,53 @@ const CompWorkspaceLayerGuidesComponent: React.FC<Props> = (props) => {
 		}
 	}
 
-	const color = "rgb(89 142 243)";
-	const anchorShadowColor = "white";
+	const transformStyle = getLayerTransformStyle(
+		PositionX,
+		PositionY,
+		AnchorX,
+		AnchorY,
+		Rotation,
+		Scale,
+	);
 
-	const W = 9 / scale;
-	const R = 5 / scale;
-	const S = 1.4 / scale;
-	const A = 3 / scale;
-	const SW = 1 / scale;
-	const SOFF = 1 / scale;
+	const { viewport } = useContext(CompWorkspaceViewportContext);
+	const areaId = useContext(AreaIdContext);
 
 	return (
 		<>
-			{[
-				[0, 0],
-				[0, 1],
-				[1, 0],
-				[1, 1],
-			].map(([x, y], i) => {
-				const pt = map.transforms[props.layerId];
-				const pos = Vec2.new(PositionX + width * x, PositionY + height * y)
-					.sub(Vec2.new(AnchorX, AnchorY))
-					.apply((pos) => rotateVec2CCW(pos, pt.rotation, pt.translate))
-					.scale(pt.scale, pt.translate)
-					.sub(Vec2.new(W / 2, W / 2));
-
-				return (
-					<g key={i}>
-						<rect
-							width={W}
-							height={W}
-							x={pos.x + SOFF}
-							y={pos.y + SOFF}
-							style={{ fill: "black" }}
-						/>
-						<rect width={W} height={W} x={pos.x} y={pos.y} style={{ fill: color }} />
-					</g>
-				);
-			})}
-			<ellipse
-				cx={PositionX}
-				cy={PositionY}
-				rx={R}
-				ry={R}
-				style={{ stroke: anchorShadowColor, strokeWidth: S + SW * 2, fill: "transparent" }}
-			/>
-			<g
-				style={{
-					transformOrigin: `${PositionX}px ${PositionY}px`,
-					transform: `rotate(${Rotation}rad)`,
-				}}
-			>
-				<line
-					y1={PositionY - R}
-					y2={PositionY - (R + A + SW)}
-					x1={PositionX}
-					x2={PositionX}
-					stroke={anchorShadowColor}
-					strokeWidth={S + SW * 2}
+			{Scale ? (
+				<rect
+					data-layer-id={layer.id}
+					width={width}
+					height={height}
+					className={s("interactionLayer")}
+					style={{
+						strokeWidth: 2 / scale / Math.abs(Scale),
+						...transformStyle,
+					}}
+					onMouseDown={(e) =>
+						compWorkspaceHandlers.onLayerRectMouseDown(
+							e,
+							props.layerId,
+							areaId,
+							viewport,
+						)
+					}
 				/>
-				<line
-					y1={PositionY + R}
-					y2={PositionY + (R + A + SW)}
-					x1={PositionX}
-					x2={PositionX}
-					stroke={anchorShadowColor}
-					strokeWidth={S + SW * 2}
+			) : null}
+			{props.selected ? (
+				<Guides
+					anchorX={AnchorX}
+					anchorY={AnchorY}
+					positionX={PositionX}
+					positionY={PositionY}
+					rotation={Rotation}
+					scale={scale}
+					height={height}
+					width={width}
+					transform={map.transforms[props.layerId]}
 				/>
-				<line
-					y1={PositionY}
-					y2={PositionY}
-					x1={PositionX - R}
-					x2={PositionX - (R + A + SW)}
-					stroke={anchorShadowColor}
-					strokeWidth={S + SW * 2}
-				/>
-				<line
-					y1={PositionY}
-					y2={PositionY}
-					x1={PositionX + R}
-					x2={PositionX + (R + A + SW)}
-					stroke={anchorShadowColor}
-					strokeWidth={S + SW * 2}
-				/>
-				<line
-					y1={PositionY - R}
-					y2={PositionY - (R + A)}
-					x1={PositionX}
-					x2={PositionX}
-					stroke={color}
-					strokeWidth={S}
-				/>
-				<line
-					y1={PositionY + R}
-					y2={PositionY + (R + A)}
-					x1={PositionX}
-					x2={PositionX}
-					stroke={color}
-					strokeWidth={S}
-				/>
-				<line
-					y1={PositionY}
-					y2={PositionY}
-					x1={PositionX - R}
-					x2={PositionX - (R + A)}
-					stroke={color}
-					strokeWidth={S}
-				/>
-				<line
-					y1={PositionY}
-					y2={PositionY}
-					x1={PositionX + R}
-					x2={PositionX + (R + A)}
-					stroke={color}
-					strokeWidth={S}
-				/>
-			</g>
-			<ellipse
-				cx={PositionX}
-				cy={PositionY}
-				rx={R}
-				ry={R}
-				style={{ stroke: color, strokeWidth: S, fill: "transparent" }}
-			/>
+			) : null}
 		</>
 	);
 };

--- a/src/shared/viewport/viewportWheelHandlers.ts
+++ b/src/shared/viewport/viewportWheelHandlers.ts
@@ -20,6 +20,8 @@ export const createViewportWheelHandlers = <T extends PossibleAreaTypes>(
 ) => {
 	const handlers = {
 		onPanStart: (areaId: string, e: React.MouseEvent) => {
+			e.stopPropagation();
+
 			const areaState = getAreaActionState<T>(areaId);
 			const initialPos = Vec2.fromEvent(e);
 
@@ -36,6 +38,8 @@ export const createViewportWheelHandlers = <T extends PossibleAreaTypes>(
 		},
 
 		onZoomClick: (e: React.MouseEvent, areaId: string) => {
+			e.stopPropagation();
+
 			const mousePos = Vec2.fromEvent(e);
 			const areaState = getAreaActionState<T>(areaId);
 

--- a/src/util/math/vec2.ts
+++ b/src/util/math/vec2.ts
@@ -1,4 +1,6 @@
-import { interpolate } from "~/util/math";
+/* eslint-disable @typescript-eslint/ban-ts-comment, @typescript-eslint/no-misused-new */
+
+import { interpolate, rotateVec2CCW } from "~/util/math";
 
 export class Vec2 {
 	public static new(vec: { x: number; y: number } | { left: number; top: number }): Vec2;
@@ -76,6 +78,10 @@ export class Vec2 {
 		return new Vec2(this.x, this.y * scale);
 	}
 
+	public rotate(rad: number, anchor?: { x: number; y: number }): Vec2 {
+		return rotateVec2CCW(this, rad, anchor) as Vec2;
+	}
+
 	public copy(): Vec2 {
 		return new Vec2(this.x, this.y);
 	}
@@ -129,6 +135,7 @@ declare global {
 		public scale(scale: number, anchor?: Vec2): Vec2;
 		public scaleX(scale: number): Vec2;
 		public scaleY(scale: number): Vec2;
+		public rotate(rad: number): Vec2;
 		public copy(): Vec2;
 		public round(): Vec2;
 		public apply(fn: (vec2: Vec2) => Vec2): Vec2;


### PR DESCRIPTION
# Changes

## Layer interaction rect

A new interaction rect has been added to the `CompWorkspaceLayerGuide`. When hovered it looks like so:

![image](https://user-images.githubusercontent.com/20321920/89346133-12fa7b80-d698-11ea-8f05-e983fa380594.png)

When the layer is selected and the interaction area is hovered, it looks like so:

![image](https://user-images.githubusercontent.com/20321920/89346183-24dc1e80-d698-11ea-8d14-b221ebc7e382.png)

Layers can be clicked to be selected, and additive selection via Shift/Command works as expected.

The user can mouse down and drag the layer around and the layer's position values will adjust. This works correctly for parented layers (move vector for each layer is transformed according to its parent's transform). If the position value is animated, the timeline is modified (like when dragging values in the `CompTimePropertyValue`).

Multiple layers can be dragged at once. If a selected layer has a parent layer that is also selected, the child layer's position values will not be modified at all. This is because moving the parent implicitly moves the child.

This makes a WORLD of difference in how the app feels. It's finally starting to feel somewhat usable (ish).


## Code reuse

A lot of the composition workspace selection logic used has near 100% overlap with the composition timeline selection logic. There is significant refactoring and code reuse to be done.

