### PR TITLE
Shift Move layers in Composition Viewport

### DIFF
--- a/src/composition/timeline/compTimeHandlers.ts
+++ b/src/composition/timeline/compTimeHandlers.ts
@@ -493,6 +493,7 @@ export const compTimeHandlers = {
 		};
 
 		mouseDownMoveAction(e, {
+			keys: [],
 			shouldAddToStack: [didCompSelectionChange(compositionId), didLayerOrderChange],
 			beforeMove: (params) => {
 				if (!additiveSelection && willBeSelected) {

--- a/src/composition/timeline/track/trackHandlers.ts
+++ b/src/composition/timeline/track/trackHandlers.ts
@@ -47,6 +47,7 @@ const actions = {
 		);
 
 		mouseDownMoveAction(e, {
+			keys: [],
 			translateX: (value) => transformGlobalToTimelineX(value, options),
 			beforeMove: (params) => {
 				const timeline = timelineState[timelineId];
@@ -113,6 +114,7 @@ const actions = {
 		},
 	) => {
 		mouseDownMoveAction(e, {
+			keys: [],
 			translateX: (value) => transformGlobalToTimelineX(value, options),
 			beforeMove: (params) => {
 				const { compositionState, compositionSelectionState } = getActionState();
@@ -220,6 +222,7 @@ const actions = {
 		);
 
 		mouseDownMoveAction(e, {
+			keys: [],
 			translateX: (value) => transformGlobalToTimelineX(value, options),
 			beforeMove: (params) => {
 				const timelineIds = getTimelineIdsReferencedByComposition(
@@ -442,6 +445,7 @@ export const trackHandlers = {
 		const additiveSelection = isKeyDown("Command") || isKeyDown("Shift");
 
 		mouseDownMoveAction(e, {
+			keys: [],
 			shouldAddToStack: didCompSelectionChange(options.compositionId),
 			translate: (vec) => transformGlobalToTrackPosition(vec, options),
 			beforeMove: () => {},

--- a/src/composition/workspace/compWorkspaceHandlers.ts
+++ b/src/composition/workspace/compWorkspaceHandlers.ts
@@ -257,7 +257,7 @@ export const compWorkspaceHandlers = {
 
 						const propertyId = layerPositionPropertyIds[layerId][i];
 						const initialValue = layerInitialPositions[layerId][axis];
-						let value = initialValue + moveVector[axis];
+						const value = initialValue + moveVector[axis];
 
 						const property = compositionState.properties[
 							propertyId

--- a/src/composition/workspace/compWorkspaceHandlers.ts
+++ b/src/composition/workspace/compWorkspaceHandlers.ts
@@ -170,6 +170,7 @@ export const compWorkspaceHandlers = {
 		);
 
 		mouseDownMoveAction(e, {
+			keys: ["Shift"],
 			shouldAddToStack: [didCompSelectionChange(compositionId), () => didMove],
 			translate: (vec) => transformGlobalToNodeEditorPosition(vec, viewport, scale, pan),
 			beforeMove: (params) => {
@@ -192,7 +193,7 @@ export const compWorkspaceHandlers = {
 					addLayerToSelection(params);
 				}
 			},
-			mouseMove: (params, { moveVector: _moveVector }) => {
+			mouseMove: (params, { moveVector: _moveVector, keyDown }) => {
 				// Layer was deselected, do not move selected layers.
 				if (additiveSelection && !willBeSelected) {
 					return;
@@ -217,6 +218,14 @@ export const compWorkspaceHandlers = {
 				for (const layerId of layerIds) {
 					const layer = compositionState.layers[layerId];
 					let moveVector = _moveVector.translated.copy();
+
+					if (keyDown.Shift) {
+						if (Math.abs(moveVector.x) > Math.abs(moveVector.y)) {
+							moveVector.y = 0;
+						} else {
+							moveVector.x = 0;
+						}
+					}
 
 					if (layer.parentLayerId) {
 						// Check if any layer in the parent chain is selected, if so skip
@@ -248,7 +257,7 @@ export const compWorkspaceHandlers = {
 
 						const propertyId = layerPositionPropertyIds[layerId][i];
 						const initialValue = layerInitialPositions[layerId][axis];
-						const value = initialValue + moveVector[axis];
+						let value = initialValue + moveVector[axis];
 
 						const property = compositionState.properties[
 							propertyId

--- a/src/util/action/mouseDownMoveAction.ts
+++ b/src/util/action/mouseDownMoveAction.ts
@@ -1,3 +1,5 @@
+import { keys } from "~/constants";
+import { isKeyDown } from "~/listener/keyboard";
 import { requestAction, RequestActionParams, ShouldAddToStackFn } from "~/listener/requestAction";
 import { getDistance } from "~/util/math";
 
@@ -6,27 +8,34 @@ interface MousePosition {
 	translated: Vec2;
 }
 
-interface Options {
+type Key = keyof typeof keys;
+
+interface MouseMoveOptions<KM> {
+	initialMousePosition: MousePosition;
+	mousePosition: MousePosition;
+	moveVector: MousePosition;
+	keyDown: KM;
+}
+
+interface Options<T extends Key, KM extends { [K in T]: boolean }> {
+	keys: T[];
 	beforeMove: (params: RequestActionParams) => void;
-	mouseMove: (
-		params: RequestActionParams,
-		options: {
-			initialMousePosition: MousePosition;
-			mousePosition: MousePosition;
-			moveVector: MousePosition;
-		},
-	) => void;
+	mouseMove: (params: RequestActionParams, options: MouseMoveOptions<KM>) => void;
 	mouseUp: (params: RequestActionParams, hasMoved: boolean) => void;
 	translate?: (vec: Vec2) => Vec2;
 	translateX?: (value: number) => number;
 	translateY?: (value: number) => number;
 	moveTreshold?: number;
 	shouldAddToStack?: ShouldAddToStackFn | ShouldAddToStackFn[];
+	tickShouldUpdate?: (options: MouseMoveOptions<KM>) => boolean;
 }
 
-export const mouseDownMoveAction = (
+export const mouseDownMoveAction = <
+	T extends Key = "Shift",
+	KM extends { [K in T]: boolean } = { [K in T]: boolean }
+>(
 	eOrInitialPos: React.MouseEvent | MouseEvent | Vec2,
-	options: Options,
+	options: Options<T, KM>,
 ): void => {
 	let translate: (vec: Vec2) => Vec2;
 
@@ -53,30 +62,81 @@ export const mouseDownMoveAction = (
 		options.beforeMove(params);
 
 		let hasMoved = false;
+		let lastKeyDownMap: KM = {} as KM;
+
+		let currentMousePosition = initialGlobalMousePosition;
+		let lastUsedMousePosition = initialGlobalMousePosition;
+
+		const tick = () => {
+			if (params.cancelled()) {
+				return;
+			}
+
+			requestAnimationFrame(tick);
+
+			if (!hasMoved) {
+				return;
+			}
+
+			let shouldUpdate = false;
+
+			const keyDownMap = (lastKeyDownMap = options.keys.reduce<KM>((acc, key) => {
+				const keyDown = isKeyDown(key) as KM[T];
+
+				if (lastKeyDownMap[key] !== keyDown) {
+					shouldUpdate = true;
+				}
+
+				acc[key] = keyDown;
+				return acc;
+			}, {} as KM));
+
+			const getOptions = () => {
+				const globalMousePosition = currentMousePosition;
+				const mousePosition: MousePosition = {
+					global: globalMousePosition,
+					translated: translate(globalMousePosition),
+				};
+
+				const moveVector: MousePosition = {
+					global: mousePosition.global.sub(initialMousePosition.global),
+					translated: mousePosition.translated.sub(initialMousePosition.translated),
+				};
+				const mouseMoveOptions: MouseMoveOptions<KM> = {
+					initialMousePosition,
+					mousePosition,
+					moveVector,
+					keyDown: keyDownMap,
+				};
+				return mouseMoveOptions;
+			};
+
+			if (options.tickShouldUpdate && options.tickShouldUpdate(getOptions())) {
+				shouldUpdate = true;
+			}
+
+			if (!shouldUpdate && lastUsedMousePosition === currentMousePosition) {
+				return;
+			}
+
+			lastUsedMousePosition = currentMousePosition;
+
+			options.mouseMove(params, getOptions());
+		};
+		requestAnimationFrame(tick);
 
 		params.addListener.repeated("mousemove", (e) => {
-			const globalMousePosition = Vec2.fromEvent(e);
-			const mousePosition: MousePosition = {
-				global: globalMousePosition,
-				translated: translate(globalMousePosition),
-			};
+			currentMousePosition = Vec2.fromEvent(e);
 
 			if (!hasMoved) {
 				if (
-					getDistance(mousePosition.global, initialMousePosition.global) >=
+					getDistance(currentMousePosition, initialMousePosition.global) >=
 					(options.moveTreshold ?? 5)
 				) {
 					return;
 				}
 				hasMoved = true;
 			}
-
-			const moveVector: MousePosition = {
-				global: mousePosition.global.sub(initialMousePosition.global),
-				translated: mousePosition.translated.sub(initialMousePosition.translated),
-			};
-
-			options.mouseMove(params, { initialMousePosition, mousePosition, moveVector });
 		});
 
 		params.addListener.once("mouseup", () => {

--- a/src/util/action/mouseDownMoveAction.ts
+++ b/src/util/action/mouseDownMoveAction.ts
@@ -10,32 +10,32 @@ interface MousePosition {
 
 type Key = keyof typeof keys;
 
-interface MouseMoveOptions<KM> {
+interface MouseMoveOptions<KeyMap> {
 	initialMousePosition: MousePosition;
 	mousePosition: MousePosition;
 	moveVector: MousePosition;
-	keyDown: KM;
+	keyDown: KeyMap;
 }
 
-interface Options<T extends Key, KM extends { [K in T]: boolean }> {
-	keys: T[];
+interface Options<K extends Key, KeyMap extends { [_ in K]: boolean }> {
+	keys: K[];
 	beforeMove: (params: RequestActionParams) => void;
-	mouseMove: (params: RequestActionParams, options: MouseMoveOptions<KM>) => void;
+	mouseMove: (params: RequestActionParams, options: MouseMoveOptions<KeyMap>) => void;
 	mouseUp: (params: RequestActionParams, hasMoved: boolean) => void;
 	translate?: (vec: Vec2) => Vec2;
 	translateX?: (value: number) => number;
 	translateY?: (value: number) => number;
 	moveTreshold?: number;
 	shouldAddToStack?: ShouldAddToStackFn | ShouldAddToStackFn[];
-	tickShouldUpdate?: (options: MouseMoveOptions<KM>) => boolean;
+	tickShouldUpdate?: (options: MouseMoveOptions<KeyMap>) => boolean;
 }
 
 export const mouseDownMoveAction = <
-	T extends Key = "Shift",
-	KM extends { [K in T]: boolean } = { [K in T]: boolean }
+	K extends Key,
+	KeyMap extends { [_ in K]: boolean } = { [_ in K]: boolean }
 >(
 	eOrInitialPos: React.MouseEvent | MouseEvent | Vec2,
-	options: Options<T, KM>,
+	options: Options<K, KeyMap>,
 ): void => {
 	let translate: (vec: Vec2) => Vec2;
 
@@ -62,7 +62,7 @@ export const mouseDownMoveAction = <
 		options.beforeMove(params);
 
 		let hasMoved = false;
-		let lastKeyDownMap: KM = {} as KM;
+		let lastKeyDownMap: KeyMap = {} as KeyMap;
 
 		let currentMousePosition = initialGlobalMousePosition;
 		let lastUsedMousePosition = initialGlobalMousePosition;
@@ -80,8 +80,8 @@ export const mouseDownMoveAction = <
 
 			let shouldUpdate = false;
 
-			const keyDownMap = (lastKeyDownMap = options.keys.reduce<KM>((acc, key) => {
-				const keyDown = isKeyDown(key) as KM[T];
+			const keyDownMap = (lastKeyDownMap = options.keys.reduce<KeyMap>((acc, key) => {
+				const keyDown = isKeyDown(key) as KeyMap[K];
 
 				if (lastKeyDownMap[key] !== keyDown) {
 					shouldUpdate = true;
@@ -89,7 +89,7 @@ export const mouseDownMoveAction = <
 
 				acc[key] = keyDown;
 				return acc;
-			}, {} as KM));
+			}, {} as KeyMap));
 
 			const getOptions = () => {
 				const globalMousePosition = currentMousePosition;
@@ -102,7 +102,7 @@ export const mouseDownMoveAction = <
 					global: mousePosition.global.sub(initialMousePosition.global),
 					translated: mousePosition.translated.sub(initialMousePosition.translated),
 				};
-				const mouseMoveOptions: MouseMoveOptions<KM> = {
+				const mouseMoveOptions: MouseMoveOptions<KeyMap> = {
 					initialMousePosition,
 					mousePosition,
 					moveVector,

--- a/src/util/action/mouseDownMoveAction.ts
+++ b/src/util/action/mouseDownMoveAction.ts
@@ -111,7 +111,7 @@ export const mouseDownMoveAction = <
 				return mouseMoveOptions;
 			};
 
-			if (options.tickShouldUpdate && options.tickShouldUpdate(getOptions())) {
+			if (!shouldUpdate && options.tickShouldUpdate?.(getOptions())) {
 				shouldUpdate = true;
 			}
 

--- a/src/util/action/mouseDownMoveAction.ts
+++ b/src/util/action/mouseDownMoveAction.ts
@@ -91,24 +91,28 @@ export const mouseDownMoveAction = <
 				return acc;
 			}, {} as KeyMap));
 
+			let _options!: MouseMoveOptions<KeyMap>;
 			const getOptions = () => {
+				if (_options) {
+					return _options;
+				}
+
 				const globalMousePosition = currentMousePosition;
 				const mousePosition: MousePosition = {
 					global: globalMousePosition,
 					translated: translate(globalMousePosition),
 				};
-
 				const moveVector: MousePosition = {
 					global: mousePosition.global.sub(initialMousePosition.global),
 					translated: mousePosition.translated.sub(initialMousePosition.translated),
 				};
-				const mouseMoveOptions: MouseMoveOptions<KeyMap> = {
+				_options = {
 					initialMousePosition,
 					mousePosition,
 					moveVector,
 					keyDown: keyDownMap,
 				};
-				return mouseMoveOptions;
+				return _options;
 			};
 
 			if (!shouldUpdate && options.tickShouldUpdate?.(getOptions())) {


### PR DESCRIPTION
Closes #50 

# Changes

## Shift move layers in Composition Viewport

The user can now hold the Shift key down to lock the movement to the significant axis. This works as expected with parented layers since the axis locking happens before the move vector is transformed.


## Ticked `mouseDownMoveAction`

When moving keyframes/control points in the graph editor when outside of the bounds, the y pan is updated every single frame. This requires the update fn to trigger every frame despite no mouse or key events having occurred. This is done by running a `tick` fn every frame which checks whether an update needs to occur.

This has been generalized to `mouseDownMoveAction`. The `Options` now require a `keys` array to be passed.

```tsx
interface Options<K extends Key, KeyMap extends { [_ in K]: boolean }> {
	keys: K[];
	// ...
}
```

If any key in this map changes, the `mouseMove` fn is triggered the next frame. The `keys` are used to construct a `keyDown` map which is passed to the `mouseMove` fn via `MouseMoveOptions`.

```tsx
interface MouseMoveOptions<KeyMap> {
	initialMousePosition: MousePosition;
	mousePosition: MousePosition;
	moveVector: MousePosition;
	keyDown: KeyMap;
}

interface Options<K extends Key, KeyMap extends { [_ in K]: boolean }> {
	keys: K[];
	mouseMove: (params: RequestActionParams, options: MouseMoveOptions<KeyMap>) => void;
	// ...
}
```

The update on out-of-bounds behavior can be triggered via providing a `tickShouldUpdate` fn.

```tsx
interface Options<K extends Key, KeyMap extends { [_ in K]: boolean }> {
	// ...
	tickShouldUpdate?: (options: MouseMoveOptions<KeyMap>) => boolean;
}
```

If test is done every tick, and if it returns true then `mouseMove` is called.



