### PR TITLE
Timeline Tweaks

### DIFF
--- a/src/hook/useActionState.ts
+++ b/src/hook/useActionState.ts
@@ -36,6 +36,8 @@ export const useActionStateEffect = (
 	useEffect(() => {
 		let prevState: ActionState = getActionStateFromApplicationState(store.getState());
 
+		callback(prevState, prevState);
+
 		const unsub = store.subscribe(() => {
 			const state = getActionStateFromApplicationState(store.getState());
 

--- a/src/shared/viewport/viewportWheelHandlers.ts
+++ b/src/shared/viewport/viewportWheelHandlers.ts
@@ -4,7 +4,7 @@ import { AreaType, TRACKPAD_ZOOM_DELTA_FAC } from "~/constants";
 import { isKeyDown } from "~/listener/keyboard";
 import { requestAction } from "~/listener/requestAction";
 import { getAreaActionState } from "~/state/stateUtils";
-import { interpolate } from "~/util/math";
+import { capToRange, interpolate } from "~/util/math";
 import { parseWheelEvent } from "~/util/wheelEvent";
 
 type PossibleAreaTypes = AreaType.NodeEditor | AreaType.Workspace;
@@ -83,7 +83,7 @@ export const createViewportWheelHandlers = <T extends PossibleAreaTypes>(
 			const areaState = getAreaActionState<T>(areaId);
 			const viewport = getAreaViewport(areaId, areaType);
 
-			const fac = interpolate(1, -deltaY < 0 ? 0.85 : 1.15, impact);
+			const fac = interpolate(1, -deltaY < 0 ? 0.85 : 1.15, capToRange(0, 2, impact));
 
 			requestAction({ history: false }, (params) => {
 				const pos = mousePos

--- a/src/timeline/TimelineGraphEditorWrapper.tsx
+++ b/src/timeline/TimelineGraphEditorWrapper.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from "react";
+import React, { useState } from "react";
 import { CompositionProperty } from "~/composition/compositionTypes";
 import { reduceCompProperties } from "~/composition/compositionUtils";
 import { getCompSelectionFromState } from "~/composition/util/compSelectionUtils";
@@ -70,14 +70,6 @@ const TimelineGraphEditorWrapperComponent: React.FC<Props> = (props) => {
 		setIdsAndColors({ timelineIds: newTimelineIds, colors });
 	});
 
-	const viewport = useMemo(() => {
-		return {
-			...props.viewport,
-			height: props.viewport.height - 32,
-			top: props.viewport.top + 32,
-		};
-	}, [props.viewport]);
-
 	if (timelineIds.length < 1) {
 		return null;
 	}
@@ -86,11 +78,7 @@ const TimelineGraphEditorWrapperComponent: React.FC<Props> = (props) => {
 		<GraphEditor
 			timelineAreaId={props.areaId}
 			ids={timelineIds}
-			viewport={{
-				...viewport,
-				height: viewport.height - 32,
-				top: viewport.top + 32,
-			}}
+			viewport={props.viewport}
 			colors={colors}
 			viewBounds={props.viewBounds}
 			length={props.compositionLength}

--- a/src/timeline/timelineHandlers.ts
+++ b/src/timeline/timelineHandlers.ts
@@ -213,7 +213,7 @@ export const timelineHandlers = {
 		const t = mousePos.x / width;
 
 		if (t < 0) {
-			console.log(t);
+			// User is pinch zooming on layer list. We just ignore this.
 			return;
 		}
 

--- a/src/trackEditor/TrackEditor.tsx
+++ b/src/trackEditor/TrackEditor.tsx
@@ -11,6 +11,7 @@ import { applyTimelineIndexAndValueShifts } from "~/timeline/timelineUtils";
 import { renderTracks } from "~/trackEditor/renderTrackEditor";
 import { trackHandlers } from "~/trackEditor/trackHandlers";
 import { useTrackEditorCanvasCursor } from "~/trackEditor/useTrackEditorCanvasCursor";
+import { separateLeftRightMouse } from "~/util/mouse";
 
 interface OwnProps {
 	compositionId: string;
@@ -98,16 +99,18 @@ const TrackEditorComponent: React.FC<Props> = (props) => {
 				ref={canvasRef}
 				height={height}
 				width={width}
-				onMouseDown={(e) => {
-					trackHandlers.onMouseDown(e, {
-						compositionId,
-						timelineAreaId: props.timelineAreaId,
-						compositionLength: composition.length,
-						panY,
-						viewBounds,
-						viewport,
-					});
-				}}
+				onMouseDown={separateLeftRightMouse({
+					left: (e) => {
+						trackHandlers.onMouseDown(e, {
+							compositionId,
+							timelineAreaId: props.timelineAreaId,
+							compositionLength: composition.length,
+							panY,
+							viewBounds,
+							viewport,
+						});
+					},
+				})}
 				onMouseMove={onMouseMove}
 			/>
 		</div>


### PR DESCRIPTION
# Changes

## Add pinch zoom support for timeline

Users may now pinch zoom on the timeline to modify the view bounds.


## Fix Graph Editor viewport issue

The viewport was off by 32. Fixed the issue that caused it.


## Call the `useActionStateEffect` callback on mount

The graph editor would not render on mount due to `useActionStateEffect` not calling the callback on mount.


## Fix view bounds stuck bug

The `Timeline` always passed the initial `viewBounds` on wheel events. This would result in the viewbounds being reset to their initial position on wheel events.


## Only draw selection rect on left click in Track Editor

Previously the selection rect could be drawn via right and middle mouse click as well.