### PR TITLE
Compound Properties within the Flow Editor

### DIFF
--- a/src/flow/flowIO.ts
+++ b/src/flow/flowIO.ts
@@ -377,7 +377,7 @@ export const getFlowNodeDefaultOutputs = (type: FlowNodeType): FlowNodeOutput[] 
 
 export const flowValidInputsToOutputsMap: { [key in ValueType]: ValueType[] } = {
 	[ValueType.Any]: [ValueType.Any, ValueType.Number, ValueType.Rect, ValueType.Vec2],
-	[ValueType.Number]: [ValueType.Any, ValueType.Number],
+	[ValueType.Number]: [ValueType.Any, ValueType.Number, ValueType.Vec2],
 	[ValueType.Rect]: [ValueType.Any, ValueType.Rect],
 	[ValueType.Vec2]: [ValueType.Any, ValueType.Vec2],
 	[ValueType.RGBAColor]: [ValueType.Any, ValueType.RGBAColor, ValueType.RGBColor],

--- a/src/flow/nodes/property/PropertyNodeSelectProperty.tsx
+++ b/src/flow/nodes/property/PropertyNodeSelectProperty.tsx
@@ -126,7 +126,12 @@ const PropertyComponent: React.FC<PropertyProps> = (props) => {
 		/>
 	);
 
-	if (property.type === "group") {
+	if (property.type === "group" || property.type === "compound") {
+		const label =
+			property.type === "group"
+				? getLayerPropertyGroupLabel(property.name)
+				: getLayerCompoundPropertyLabel(property.name);
+
 		return (
 			<>
 				<div className={s("container")} onClick={onClick}>
@@ -135,51 +140,21 @@ const PropertyComponent: React.FC<PropertyProps> = (props) => {
 						className={s("contentContainer")}
 						style={{ marginLeft: CONTEXT_MENU_OPTION_PADDING_LEFT + depthLeft }}
 					>
-						<div className={s("name")}>{getLayerPropertyGroupLabel(property.name)}</div>
+						<div className={s("name")}>{label}</div>
 					</div>
 				</div>
-				{property.properties.map((propertyId) => (
-					<SingleProperty
-						selectedPropertyId={selectedPropertyId}
-						propertyId={propertyId}
-						onSelectProperty={props.onSelectProperty}
-						depth={depth + 1}
-						key={propertyId}
-					/>
-				))}
+				{property.type === "group" &&
+					property.properties.map((propertyId) => (
+						<SingleProperty
+							selectedPropertyId={selectedPropertyId}
+							propertyId={propertyId}
+							onSelectProperty={props.onSelectProperty}
+							depth={depth + 1}
+							key={propertyId}
+						/>
+					))}
 			</>
 		);
-	}
-
-	if (property.type === "compound") {
-		return (
-			<>
-				{property.properties.map((propertyId) => (
-					<SingleProperty
-						selectedPropertyId={selectedPropertyId}
-						propertyId={propertyId}
-						onSelectProperty={props.onSelectProperty}
-						depth={depth}
-						key={propertyId}
-					/>
-				))}
-			</>
-		);
-
-		/**
-		 * @todo Select compound properties directly
-		 */
-		// return (
-		// 	<div className={s("container")} onClick={onClick}>
-		// 		{activeDot}
-		// 		<div
-		// 			className={s("contentContainer")}
-		// 			style={{ marginLeft: CONTEXT_MENU_OPTION_PADDING_LEFT + depthLeft }}
-		// 		>
-		// 			<div className={s("name")}>{getLayerCompoundPropertyLabel(property.name)}</div>
-		// 		</div>
-		// 	</div>
-		// );
 	}
 
 	return (


### PR DESCRIPTION
# Changes

## Select compound properties in Flow Editor

The Property IO nodes now allow for compound properties to be selected. And notably, the individual properties of compound properties may no longer be directly selected.

Instead, when a compound property is selected in the Property IO nodes, the compound AND individual properties are exposed.

![image](https://user-images.githubusercontent.com/20321920/98468048-a3cd7f80-21d0-11eb-9b01-dcb40deadc45.png)


## Allow number to be parsed as Vec2

Within the flow editor, number values may now be converted to Vec2. Both axes of the Vec2 will be the value of the number.

This is useful for setting compound properties (notably, Scale) with a single numeric value.

![image](https://user-images.githubusercontent.com/20321920/98468140-058de980-21d1-11eb-983b-886db01de193.png)


## Throw error if invalid value is provided to `property_output` nodes

Currently we don't ensure that the values provided to `property_output` are of the correct type, which leads to error down the line.

We now parse each value provided to `property_output` nodes to ensure that they are correct before being used.

