### PR TITLE
Reduce Property interface footerprint

### DIFF
--- a/src/composition/compositionTypes.ts
+++ b/src/composition/compositionTypes.ts
@@ -11,7 +11,6 @@ import {
 	RGBAColor,
 	RGBColor,
 	TransformBehavior,
-	ValueFormat,
 	ValueType,
 } from "~/types";
 
@@ -92,11 +91,7 @@ export type Property = {
 	layerId: string;
 	compositionId: string;
 	name: PropertyName;
-	valueFormat?: ValueFormat;
 	timelineId: string;
-	color?: string;
-	min?: number;
-	max?: number;
 	compoundPropertyId: string;
 } & (
 	| {

--- a/src/composition/compositionTypes.ts
+++ b/src/composition/compositionTypes.ts
@@ -1,17 +1,9 @@
 import {
 	CompoundPropertyName,
-	FillRule,
 	KeySelectionMap,
 	LayerType,
-	LineCap,
-	LineJoin,
-	OriginBehavior,
 	PropertyGroupName,
 	PropertyName,
-	RGBAColor,
-	RGBColor,
-	TransformBehavior,
-	ValueType,
 } from "~/types";
 
 export interface Composition {
@@ -93,56 +85,8 @@ export type Property = {
 	name: PropertyName;
 	timelineId: string;
 	compoundPropertyId: string;
-} & (
-	| {
-			valueType: ValueType.Any;
-			value: any;
-	  }
-	| {
-			valueType: ValueType.RGBAColor;
-			value: RGBAColor;
-	  }
-	| {
-			valueType: ValueType.RGBColor;
-			value: RGBColor;
-	  }
-	| {
-			valueType: ValueType.Number;
-			value: number;
-	  }
-	| {
-			valueType: ValueType.Rect;
-			value: Rect;
-	  }
-	| {
-			valueType: ValueType.Vec2;
-			value: Vec2;
-	  }
-	| {
-			valueType: ValueType.TransformBehavior;
-			value: TransformBehavior;
-	  }
-	| {
-			valueType: ValueType.OriginBehavior;
-			value: OriginBehavior;
-	  }
-	| {
-			valueType: ValueType.Path;
-			value: string;
-	  }
-	| {
-			valueType: ValueType.FillRule;
-			value: FillRule;
-	  }
-	| {
-			valueType: ValueType.LineCap;
-			value: LineCap;
-	  }
-	| {
-			valueType: ValueType.LineJoin;
-			value: LineJoin;
-	  }
-);
+	value: any;
+};
 
 export interface CreatePropertyOptions {
 	createId: () => string;

--- a/src/composition/factories/arrayModifierPropertiesFactory.ts
+++ b/src/composition/factories/arrayModifierPropertiesFactory.ts
@@ -5,7 +5,7 @@ import {
 	PropertyGroup,
 } from "~/composition/compositionTypes";
 import { transformPropertiesFactory } from "~/composition/factories/transformPropertiesFactory";
-import { CompoundPropertyName, PropertyGroupName, PropertyName, ValueType } from "~/types";
+import { CompoundPropertyName, PropertyGroupName, PropertyName } from "~/types";
 
 export const arrayModifierPropertiesFactory = (opts: CreatePropertyOptions) => {
 	const propertyId = opts.createId();
@@ -32,7 +32,6 @@ export const arrayModifierPropertiesFactory = (opts: CreatePropertyOptions) => {
 		name: PropertyName.ArrayModifier_TransformBehavior,
 		timelineId: "",
 		value: "absolute_for_computed",
-		valueType: ValueType.TransformBehavior,
 		compoundPropertyId: "",
 	};
 
@@ -47,7 +46,6 @@ export const arrayModifierPropertiesFactory = (opts: CreatePropertyOptions) => {
 		name: PropertyName.ArrayModifier_OriginBehavior,
 		timelineId: "",
 		value: "relative",
-		valueType: ValueType.OriginBehavior,
 		compoundPropertyId: "",
 	};
 
@@ -62,7 +60,6 @@ export const arrayModifierPropertiesFactory = (opts: CreatePropertyOptions) => {
 		name: PropertyName.ArrayModifier_RotationCorrection,
 		timelineId: "",
 		value: 0,
-		valueType: ValueType.Number,
 		compoundPropertyId: "",
 	};
 
@@ -77,7 +74,6 @@ export const arrayModifierPropertiesFactory = (opts: CreatePropertyOptions) => {
 		name: PropertyName.ArrayModifier_OriginX,
 		timelineId: "",
 		value: 0,
-		valueType: ValueType.Number,
 		compoundPropertyId: "",
 	};
 	const originY: Property = {
@@ -88,7 +84,6 @@ export const arrayModifierPropertiesFactory = (opts: CreatePropertyOptions) => {
 		name: PropertyName.ArrayModifier_OriginY,
 		timelineId: "",
 		value: 0,
-		valueType: ValueType.Number,
 		compoundPropertyId: "",
 	};
 	const origin: CompoundProperty = {
@@ -114,7 +109,6 @@ export const arrayModifierPropertiesFactory = (opts: CreatePropertyOptions) => {
 		name: PropertyName.ArrayModifier_Count,
 		timelineId: "",
 		value: 1,
-		valueType: ValueType.Number,
 		compoundPropertyId: "",
 	};
 

--- a/src/composition/factories/arrayModifierPropertiesFactory.ts
+++ b/src/composition/factories/arrayModifierPropertiesFactory.ts
@@ -5,7 +5,6 @@ import {
 	PropertyGroup,
 } from "~/composition/compositionTypes";
 import { transformPropertiesFactory } from "~/composition/factories/transformPropertiesFactory";
-import { TimelineColors } from "~/constants";
 import { CompoundPropertyName, PropertyGroupName, PropertyName, ValueType } from "~/types";
 
 export const arrayModifierPropertiesFactory = (opts: CreatePropertyOptions) => {
@@ -34,7 +33,6 @@ export const arrayModifierPropertiesFactory = (opts: CreatePropertyOptions) => {
 		timelineId: "",
 		value: "absolute_for_computed",
 		valueType: ValueType.TransformBehavior,
-		color: TimelineColors.Height,
 		compoundPropertyId: "",
 	};
 
@@ -50,7 +48,6 @@ export const arrayModifierPropertiesFactory = (opts: CreatePropertyOptions) => {
 		timelineId: "",
 		value: "relative",
 		valueType: ValueType.OriginBehavior,
-		color: TimelineColors.Height,
 		compoundPropertyId: "",
 	};
 
@@ -66,7 +63,6 @@ export const arrayModifierPropertiesFactory = (opts: CreatePropertyOptions) => {
 		timelineId: "",
 		value: 0,
 		valueType: ValueType.Number,
-		color: TimelineColors.Height,
 		compoundPropertyId: "",
 	};
 
@@ -82,7 +78,6 @@ export const arrayModifierPropertiesFactory = (opts: CreatePropertyOptions) => {
 		timelineId: "",
 		value: 0,
 		valueType: ValueType.Number,
-		color: TimelineColors.XPosition,
 		compoundPropertyId: "",
 	};
 	const originY: Property = {
@@ -94,7 +89,6 @@ export const arrayModifierPropertiesFactory = (opts: CreatePropertyOptions) => {
 		timelineId: "",
 		value: 0,
 		valueType: ValueType.Number,
-		color: TimelineColors.XPosition,
 		compoundPropertyId: "",
 	};
 	const origin: CompoundProperty = {
@@ -121,7 +115,6 @@ export const arrayModifierPropertiesFactory = (opts: CreatePropertyOptions) => {
 		timelineId: "",
 		value: 1,
 		valueType: ValueType.Number,
-		color: TimelineColors.Height,
 		compoundPropertyId: "",
 	};
 

--- a/src/composition/factories/compositionLayerPropertiesFactory.ts
+++ b/src/composition/factories/compositionLayerPropertiesFactory.ts
@@ -4,7 +4,7 @@ import {
 	Property,
 	PropertyGroup,
 } from "~/composition/compositionTypes";
-import { PropertyGroupName, PropertyName, ValueType } from "~/types";
+import { PropertyGroupName, PropertyName } from "~/types";
 
 const dimensionProperties = (opts: CreatePropertyOptions): CreateLayerPropertyGroup => {
 	const { compositionId, createId, layerId } = opts;
@@ -17,7 +17,6 @@ const dimensionProperties = (opts: CreatePropertyOptions): CreateLayerPropertyGr
 			compositionId,
 			name: PropertyName.Width,
 			timelineId: "",
-			valueType: ValueType.Number,
 			value: 100,
 			compoundPropertyId: "",
 		},
@@ -28,7 +27,6 @@ const dimensionProperties = (opts: CreatePropertyOptions): CreateLayerPropertyGr
 			compositionId,
 			name: PropertyName.Height,
 			timelineId: "",
-			valueType: ValueType.Number,
 			value: 100,
 			compoundPropertyId: "",
 		},

--- a/src/composition/factories/compositionLayerPropertiesFactory.ts
+++ b/src/composition/factories/compositionLayerPropertiesFactory.ts
@@ -4,7 +4,6 @@ import {
 	Property,
 	PropertyGroup,
 } from "~/composition/compositionTypes";
-import { TimelineColors } from "~/constants";
 import { PropertyGroupName, PropertyName, ValueType } from "~/types";
 
 const dimensionProperties = (opts: CreatePropertyOptions): CreateLayerPropertyGroup => {
@@ -19,9 +18,7 @@ const dimensionProperties = (opts: CreatePropertyOptions): CreateLayerPropertyGr
 			name: PropertyName.Width,
 			timelineId: "",
 			valueType: ValueType.Number,
-			color: TimelineColors.Width,
 			value: 100,
-			min: 0,
 			compoundPropertyId: "",
 		},
 		{
@@ -32,9 +29,7 @@ const dimensionProperties = (opts: CreatePropertyOptions): CreateLayerPropertyGr
 			name: PropertyName.Height,
 			timelineId: "",
 			valueType: ValueType.Number,
-			color: TimelineColors.Height,
 			value: 100,
-			min: 0,
 			compoundPropertyId: "",
 		},
 	];

--- a/src/composition/factories/ellipseLayerPropertiesFactory.ts
+++ b/src/composition/factories/ellipseLayerPropertiesFactory.ts
@@ -4,7 +4,6 @@ import {
 	Property,
 	PropertyGroup,
 } from "~/composition/compositionTypes";
-import { TimelineColors } from "~/constants";
 import { PropertyGroupName, PropertyName, RGBAColor, ValueType } from "~/types";
 
 export interface EllipseProperties {
@@ -30,9 +29,7 @@ const structureProperties = (
 			name: PropertyName.OuterRadius,
 			timelineId: "",
 			valueType: ValueType.Number,
-			color: TimelineColors.Width,
 			value: radius,
-			min: 0,
 			compoundPropertyId: "",
 		},
 		{
@@ -43,9 +40,7 @@ const structureProperties = (
 			name: PropertyName.InnerRadius,
 			timelineId: "",
 			valueType: ValueType.Number,
-			color: TimelineColors.Width,
 			value: 0,
-			min: 0,
 			compoundPropertyId: "",
 		},
 	];
@@ -81,9 +76,7 @@ const contentProperties = (
 			name: PropertyName.Fill,
 			timelineId: "",
 			valueType: ValueType.RGBAColor,
-			color: TimelineColors.Width,
 			value: fill,
-			min: 0,
 			compoundPropertyId: "",
 		},
 		{
@@ -94,9 +87,7 @@ const contentProperties = (
 			name: PropertyName.StrokeWidth,
 			timelineId: "",
 			valueType: ValueType.Number,
-			color: TimelineColors.Height,
 			value: strokeWidth,
-			min: 0,
 			compoundPropertyId: "",
 		},
 		{
@@ -107,9 +98,7 @@ const contentProperties = (
 			name: PropertyName.StrokeColor,
 			timelineId: "",
 			valueType: ValueType.RGBAColor,
-			color: TimelineColors.Height,
 			value: strokeColor,
-			min: 0,
 			compoundPropertyId: "",
 		},
 	];

--- a/src/composition/factories/ellipseLayerPropertiesFactory.ts
+++ b/src/composition/factories/ellipseLayerPropertiesFactory.ts
@@ -4,7 +4,7 @@ import {
 	Property,
 	PropertyGroup,
 } from "~/composition/compositionTypes";
-import { PropertyGroupName, PropertyName, RGBAColor, ValueType } from "~/types";
+import { PropertyGroupName, PropertyName, RGBAColor } from "~/types";
 
 export interface EllipseProperties {
 	fill: RGBAColor;
@@ -28,7 +28,6 @@ const structureProperties = (
 			compositionId,
 			name: PropertyName.OuterRadius,
 			timelineId: "",
-			valueType: ValueType.Number,
 			value: radius,
 			compoundPropertyId: "",
 		},
@@ -39,7 +38,6 @@ const structureProperties = (
 			compositionId,
 			name: PropertyName.InnerRadius,
 			timelineId: "",
-			valueType: ValueType.Number,
 			value: 0,
 			compoundPropertyId: "",
 		},
@@ -75,7 +73,6 @@ const contentProperties = (
 			compositionId,
 			name: PropertyName.Fill,
 			timelineId: "",
-			valueType: ValueType.RGBAColor,
 			value: fill,
 			compoundPropertyId: "",
 		},
@@ -86,7 +83,6 @@ const contentProperties = (
 			compositionId,
 			name: PropertyName.StrokeWidth,
 			timelineId: "",
-			valueType: ValueType.Number,
 			value: strokeWidth,
 			compoundPropertyId: "",
 		},
@@ -97,7 +93,6 @@ const contentProperties = (
 			compositionId,
 			name: PropertyName.StrokeColor,
 			timelineId: "",
-			valueType: ValueType.RGBAColor,
 			value: strokeColor,
 			compoundPropertyId: "",
 		},

--- a/src/composition/factories/lineLayerPropertiesFactory.ts
+++ b/src/composition/factories/lineLayerPropertiesFactory.ts
@@ -4,7 +4,6 @@ import {
 	Property,
 	PropertyGroup,
 } from "~/composition/compositionTypes";
-import { TimelineColors } from "~/constants";
 import { LineCap, PropertyGroupName, PropertyName, RGBAColor, ValueType } from "~/types";
 
 export interface LineProperties {
@@ -30,9 +29,7 @@ const contentProperties = (
 			name: PropertyName.Width,
 			timelineId: "",
 			valueType: ValueType.Number,
-			color: TimelineColors.Width,
 			value: width,
-			min: 0,
 			compoundPropertyId: "",
 		},
 		{
@@ -43,9 +40,7 @@ const contentProperties = (
 			name: PropertyName.StrokeWidth,
 			timelineId: "",
 			valueType: ValueType.Number,
-			color: TimelineColors.Height,
 			value: strokeWidth,
-			min: 0,
 			compoundPropertyId: "",
 		},
 		{
@@ -56,9 +51,7 @@ const contentProperties = (
 			name: PropertyName.StrokeColor,
 			timelineId: "",
 			valueType: ValueType.RGBAColor,
-			color: TimelineColors.Height,
 			value: strokeColor,
-			min: 0,
 			compoundPropertyId: "",
 		},
 		{
@@ -69,7 +62,6 @@ const contentProperties = (
 			name: PropertyName.LineCap,
 			timelineId: "",
 			valueType: ValueType.LineCap,
-			color: TimelineColors.Height,
 			value: lineCap,
 			compoundPropertyId: "",
 		},

--- a/src/composition/factories/lineLayerPropertiesFactory.ts
+++ b/src/composition/factories/lineLayerPropertiesFactory.ts
@@ -4,7 +4,7 @@ import {
 	Property,
 	PropertyGroup,
 } from "~/composition/compositionTypes";
-import { LineCap, PropertyGroupName, PropertyName, RGBAColor, ValueType } from "~/types";
+import { LineCap, PropertyGroupName, PropertyName, RGBAColor } from "~/types";
 
 export interface LineProperties {
 	strokeColor: RGBAColor;
@@ -28,7 +28,6 @@ const contentProperties = (
 			compositionId,
 			name: PropertyName.Width,
 			timelineId: "",
-			valueType: ValueType.Number,
 			value: width,
 			compoundPropertyId: "",
 		},
@@ -39,7 +38,6 @@ const contentProperties = (
 			compositionId,
 			name: PropertyName.StrokeWidth,
 			timelineId: "",
-			valueType: ValueType.Number,
 			value: strokeWidth,
 			compoundPropertyId: "",
 		},
@@ -50,7 +48,6 @@ const contentProperties = (
 			compositionId,
 			name: PropertyName.StrokeColor,
 			timelineId: "",
-			valueType: ValueType.RGBAColor,
 			value: strokeColor,
 			compoundPropertyId: "",
 		},
@@ -61,7 +58,6 @@ const contentProperties = (
 			compositionId,
 			name: PropertyName.LineCap,
 			timelineId: "",
-			valueType: ValueType.LineCap,
 			value: lineCap,
 			compoundPropertyId: "",
 		},

--- a/src/composition/factories/rectLayerPropertiesFactory.ts
+++ b/src/composition/factories/rectLayerPropertiesFactory.ts
@@ -4,7 +4,7 @@ import {
 	Property,
 	PropertyGroup,
 } from "~/composition/compositionTypes";
-import { PropertyGroupName, PropertyName, RGBAColor, ValueType } from "~/types";
+import { PropertyGroupName, PropertyName, RGBAColor } from "~/types";
 
 export interface RectProperties {
 	fill: RGBAColor;
@@ -29,7 +29,6 @@ const dimensionProperties = (
 			compositionId,
 			name: PropertyName.Width,
 			timelineId: "",
-			valueType: ValueType.Number,
 			value: width,
 			compoundPropertyId: "",
 		},
@@ -40,7 +39,6 @@ const dimensionProperties = (
 			compositionId,
 			name: PropertyName.Height,
 			timelineId: "",
-			valueType: ValueType.Number,
 			value: height,
 			compoundPropertyId: "",
 		},
@@ -76,7 +74,6 @@ const contentProperties = (
 			compositionId,
 			name: PropertyName.Fill,
 			timelineId: "",
-			valueType: ValueType.RGBAColor,
 			value: fill,
 			compoundPropertyId: "",
 		},
@@ -87,7 +84,6 @@ const contentProperties = (
 			compositionId,
 			name: PropertyName.StrokeWidth,
 			timelineId: "",
-			valueType: ValueType.Number,
 			value: strokeWidth,
 			compoundPropertyId: "",
 		},
@@ -98,7 +94,6 @@ const contentProperties = (
 			compositionId,
 			name: PropertyName.StrokeColor,
 			timelineId: "",
-			valueType: ValueType.RGBAColor,
 			value: strokeColor,
 			compoundPropertyId: "",
 		},
@@ -109,7 +104,6 @@ const contentProperties = (
 			compositionId,
 			name: PropertyName.BorderRadius,
 			timelineId: "",
-			valueType: ValueType.Number,
 			value: 0,
 			compoundPropertyId: "",
 		},

--- a/src/composition/factories/rectLayerPropertiesFactory.ts
+++ b/src/composition/factories/rectLayerPropertiesFactory.ts
@@ -4,7 +4,6 @@ import {
 	Property,
 	PropertyGroup,
 } from "~/composition/compositionTypes";
-import { TimelineColors } from "~/constants";
 import { PropertyGroupName, PropertyName, RGBAColor, ValueType } from "~/types";
 
 export interface RectProperties {
@@ -31,9 +30,7 @@ const dimensionProperties = (
 			name: PropertyName.Width,
 			timelineId: "",
 			valueType: ValueType.Number,
-			color: TimelineColors.Width,
 			value: width,
-			min: 0,
 			compoundPropertyId: "",
 		},
 		{
@@ -44,9 +41,7 @@ const dimensionProperties = (
 			name: PropertyName.Height,
 			timelineId: "",
 			valueType: ValueType.Number,
-			color: TimelineColors.Height,
 			value: height,
-			min: 0,
 			compoundPropertyId: "",
 		},
 	];
@@ -82,9 +77,7 @@ const contentProperties = (
 			name: PropertyName.Fill,
 			timelineId: "",
 			valueType: ValueType.RGBAColor,
-			color: TimelineColors.Width,
 			value: fill,
-			min: 0,
 			compoundPropertyId: "",
 		},
 		{
@@ -95,9 +88,7 @@ const contentProperties = (
 			name: PropertyName.StrokeWidth,
 			timelineId: "",
 			valueType: ValueType.Number,
-			color: TimelineColors.Height,
 			value: strokeWidth,
-			min: 0,
 			compoundPropertyId: "",
 		},
 		{
@@ -108,9 +99,7 @@ const contentProperties = (
 			name: PropertyName.StrokeColor,
 			timelineId: "",
 			valueType: ValueType.RGBAColor,
-			color: TimelineColors.Height,
 			value: strokeColor,
-			min: 0,
 			compoundPropertyId: "",
 		},
 		{
@@ -121,9 +110,7 @@ const contentProperties = (
 			name: PropertyName.BorderRadius,
 			timelineId: "",
 			valueType: ValueType.Number,
-			color: TimelineColors.Height,
 			value: 0,
-			min: 0,
 			compoundPropertyId: "",
 		},
 	];

--- a/src/composition/factories/shapeLayerPathPropertiesFactory.ts
+++ b/src/composition/factories/shapeLayerPathPropertiesFactory.ts
@@ -5,7 +5,6 @@ import {
 	PropertyGroup,
 } from "~/composition/compositionTypes";
 import { transformPropertiesFactory } from "~/composition/factories/transformPropertiesFactory";
-import { TimelineColors } from "~/constants";
 import {
 	FillRule,
 	LineCap,
@@ -13,7 +12,6 @@ import {
 	PropertyGroupName,
 	PropertyName,
 	RGBAColor,
-	ValueFormat,
 	ValueType,
 } from "~/types";
 
@@ -76,7 +74,6 @@ export const createShapeLayerShapeGroup = (
 				compositionId,
 				layerId,
 				timelineId: "",
-				color: TimelineColors.Height,
 				compoundPropertyId: "",
 			},
 			{
@@ -88,7 +85,6 @@ export const createShapeLayerShapeGroup = (
 				compositionId,
 				layerId,
 				timelineId: "",
-				color: TimelineColors.Height,
 				compoundPropertyId: "",
 			},
 			{
@@ -96,14 +92,10 @@ export const createShapeLayerShapeGroup = (
 				name: PropertyName.Opacity,
 				valueType: ValueType.Number,
 				value: fillOpacity,
-				min: 0,
-				max: 1,
-				valueFormat: ValueFormat.Percentage,
 				id: opts.createId(),
 				compositionId,
 				layerId,
 				timelineId: "",
-				color: TimelineColors.Height,
 				compoundPropertyId: "",
 			},
 		];
@@ -135,7 +127,6 @@ export const createShapeLayerShapeGroup = (
 				compositionId,
 				layerId,
 				timelineId: "",
-				color: TimelineColors.Height,
 				compoundPropertyId: "",
 			},
 			{
@@ -143,12 +134,10 @@ export const createShapeLayerShapeGroup = (
 				name: PropertyName.StrokeWidth,
 				valueType: ValueType.Number,
 				value: strokeWidth,
-				min: 0,
 				id: opts.createId(),
 				compositionId,
 				layerId,
 				timelineId: "",
-				color: TimelineColors.Height,
 				compoundPropertyId: "",
 			},
 			{
@@ -156,14 +145,10 @@ export const createShapeLayerShapeGroup = (
 				name: PropertyName.Opacity,
 				valueType: ValueType.Number,
 				value: 1,
-				min: 0,
-				max: 1,
-				valueFormat: ValueFormat.Percentage,
 				id: opts.createId(),
 				compositionId,
 				layerId,
 				timelineId: "",
-				color: TimelineColors.Height,
 				compoundPropertyId: "",
 			},
 			{
@@ -175,7 +160,6 @@ export const createShapeLayerShapeGroup = (
 				compositionId,
 				layerId,
 				timelineId: "",
-				color: TimelineColors.Height,
 				compoundPropertyId: "",
 			},
 			{
@@ -187,7 +171,6 @@ export const createShapeLayerShapeGroup = (
 				compositionId,
 				layerId,
 				timelineId: "",
-				color: TimelineColors.Height,
 				compoundPropertyId: "",
 			},
 			{
@@ -195,12 +178,10 @@ export const createShapeLayerShapeGroup = (
 				name: PropertyName.MiterLimit,
 				valueType: ValueType.Number,
 				value: miterLimit,
-				min: 1,
 				id: opts.createId(),
 				compositionId,
 				layerId,
 				timelineId: "",
-				color: TimelineColors.Height,
 				compoundPropertyId: "",
 			},
 		];
@@ -236,7 +217,6 @@ export const createShapeLayerShapeGroup = (
 			compositionId,
 			layerId,
 			timelineId: "",
-			color: TimelineColors.Height,
 			compoundPropertyId: "",
 		};
 

--- a/src/composition/factories/shapeLayerPathPropertiesFactory.ts
+++ b/src/composition/factories/shapeLayerPathPropertiesFactory.ts
@@ -5,15 +5,7 @@ import {
 	PropertyGroup,
 } from "~/composition/compositionTypes";
 import { transformPropertiesFactory } from "~/composition/factories/transformPropertiesFactory";
-import {
-	FillRule,
-	LineCap,
-	LineJoin,
-	PropertyGroupName,
-	PropertyName,
-	RGBAColor,
-	ValueType,
-} from "~/types";
+import { FillRule, LineCap, LineJoin, PropertyGroupName, PropertyName, RGBAColor } from "~/types";
 
 interface Options {
 	fill: RGBAColor;
@@ -68,7 +60,6 @@ export const createShapeLayerShapeGroup = (
 			{
 				type: "property",
 				name: PropertyName.RGBAColor,
-				valueType: ValueType.RGBAColor,
 				value: fill,
 				id: opts.createId(),
 				compositionId,
@@ -79,7 +70,6 @@ export const createShapeLayerShapeGroup = (
 			{
 				type: "property",
 				name: PropertyName.FillRule,
-				valueType: ValueType.FillRule,
 				value: fillRule,
 				id: opts.createId(),
 				compositionId,
@@ -90,7 +80,6 @@ export const createShapeLayerShapeGroup = (
 			{
 				type: "property",
 				name: PropertyName.Opacity,
-				valueType: ValueType.Number,
 				value: fillOpacity,
 				id: opts.createId(),
 				compositionId,
@@ -121,7 +110,6 @@ export const createShapeLayerShapeGroup = (
 			{
 				type: "property",
 				name: PropertyName.RGBAColor,
-				valueType: ValueType.RGBAColor,
 				value: strokeColor,
 				id: opts.createId(),
 				compositionId,
@@ -132,7 +120,6 @@ export const createShapeLayerShapeGroup = (
 			{
 				type: "property",
 				name: PropertyName.StrokeWidth,
-				valueType: ValueType.Number,
 				value: strokeWidth,
 				id: opts.createId(),
 				compositionId,
@@ -143,7 +130,6 @@ export const createShapeLayerShapeGroup = (
 			{
 				type: "property",
 				name: PropertyName.Opacity,
-				valueType: ValueType.Number,
 				value: 1,
 				id: opts.createId(),
 				compositionId,
@@ -154,7 +140,6 @@ export const createShapeLayerShapeGroup = (
 			{
 				type: "property",
 				name: PropertyName.LineCap,
-				valueType: ValueType.LineCap,
 				value: lineCap,
 				id: opts.createId(),
 				compositionId,
@@ -165,7 +150,6 @@ export const createShapeLayerShapeGroup = (
 			{
 				type: "property",
 				name: PropertyName.LineJoin,
-				valueType: ValueType.LineJoin,
 				value: lineJoin,
 				id: opts.createId(),
 				compositionId,
@@ -176,7 +160,6 @@ export const createShapeLayerShapeGroup = (
 			{
 				type: "property",
 				name: PropertyName.MiterLimit,
-				valueType: ValueType.Number,
 				value: miterLimit,
 				id: opts.createId(),
 				compositionId,
@@ -211,7 +194,6 @@ export const createShapeLayerShapeGroup = (
 		const path: Property = {
 			type: "property",
 			name: PropertyName.ShapeLayer_Path,
-			valueType: ValueType.Path,
 			value: pathId,
 			id: opts.createId(),
 			compositionId,

--- a/src/composition/factories/transformPropertiesFactory.ts
+++ b/src/composition/factories/transformPropertiesFactory.ts
@@ -5,7 +5,7 @@ import {
 	Property,
 	PropertyGroup,
 } from "~/composition/compositionTypes";
-import { DEFAULT_LAYER_TRANSFORM, TimelineColors } from "~/constants";
+import { DEFAULT_LAYER_TRANSFORM } from "~/constants";
 import {
 	CompoundPropertyName,
 	LayerTransform,
@@ -37,7 +37,6 @@ export const transformPropertiesFactory = (
 		timelineId: "",
 		valueType: ValueType.Number,
 		value: transform.translate.x,
-		color: TimelineColors.XPosition,
 		compoundPropertyId: positionId,
 	};
 	const positionY: Property = {
@@ -49,7 +48,6 @@ export const transformPropertiesFactory = (
 		timelineId: "",
 		valueType: ValueType.Number,
 		value: transform.translate.y,
-		color: TimelineColors.YPosition,
 		compoundPropertyId: positionId,
 	};
 	const position: CompoundProperty = {
@@ -73,7 +71,6 @@ export const transformPropertiesFactory = (
 		timelineId: "",
 		valueType: ValueType.Number,
 		value: transform.anchor.x,
-		color: TimelineColors.XPosition,
 		compoundPropertyId: anchorId,
 	};
 	const anchorY: Property = {
@@ -85,7 +82,6 @@ export const transformPropertiesFactory = (
 		timelineId: "",
 		valueType: ValueType.Number,
 		value: transform.anchor.y,
-		color: TimelineColors.YPosition,
 		compoundPropertyId: anchorId,
 	};
 	const anchor: CompoundProperty = {
@@ -109,7 +105,6 @@ export const transformPropertiesFactory = (
 		timelineId: "",
 		valueType: ValueType.Number,
 		value: transform.scaleX,
-		color: TimelineColors.YPosition,
 		compoundPropertyId: scaleId,
 	};
 	const scaleY: Property = {
@@ -121,7 +116,6 @@ export const transformPropertiesFactory = (
 		timelineId: "",
 		valueType: ValueType.Number,
 		value: transform.scaleY,
-		color: TimelineColors.YPosition,
 		compoundPropertyId: scaleId,
 	};
 	const scale: CompoundProperty = {
@@ -149,7 +143,6 @@ export const transformPropertiesFactory = (
 			timelineId: "",
 			valueType: ValueType.Number,
 			value: transform.rotation,
-			color: TimelineColors.YPosition,
 			compoundPropertyId: "",
 		},
 		{
@@ -161,9 +154,6 @@ export const transformPropertiesFactory = (
 			timelineId: "",
 			valueType: ValueType.Number,
 			value: 1,
-			color: TimelineColors.YPosition,
-			max: 1,
-			min: 0,
 			compoundPropertyId: "",
 		},
 	];

--- a/src/composition/factories/transformPropertiesFactory.ts
+++ b/src/composition/factories/transformPropertiesFactory.ts
@@ -6,13 +6,7 @@ import {
 	PropertyGroup,
 } from "~/composition/compositionTypes";
 import { DEFAULT_LAYER_TRANSFORM } from "~/constants";
-import {
-	CompoundPropertyName,
-	LayerTransform,
-	PropertyGroupName,
-	PropertyName,
-	ValueType,
-} from "~/types";
+import { CompoundPropertyName, LayerTransform, PropertyGroupName, PropertyName } from "~/types";
 
 export const transformPropertiesFactory = (
 	opts: CreatePropertyOptions,
@@ -35,7 +29,6 @@ export const transformPropertiesFactory = (
 		compositionId,
 		name: PropertyName.PositionX,
 		timelineId: "",
-		valueType: ValueType.Number,
 		value: transform.translate.x,
 		compoundPropertyId: positionId,
 	};
@@ -46,7 +39,6 @@ export const transformPropertiesFactory = (
 		compositionId,
 		name: PropertyName.PositionY,
 		timelineId: "",
-		valueType: ValueType.Number,
 		value: transform.translate.y,
 		compoundPropertyId: positionId,
 	};
@@ -69,7 +61,6 @@ export const transformPropertiesFactory = (
 		compositionId,
 		name: PropertyName.AnchorX,
 		timelineId: "",
-		valueType: ValueType.Number,
 		value: transform.anchor.x,
 		compoundPropertyId: anchorId,
 	};
@@ -80,7 +71,6 @@ export const transformPropertiesFactory = (
 		compositionId,
 		name: PropertyName.AnchorY,
 		timelineId: "",
-		valueType: ValueType.Number,
 		value: transform.anchor.y,
 		compoundPropertyId: anchorId,
 	};
@@ -103,7 +93,6 @@ export const transformPropertiesFactory = (
 		compositionId,
 		name: PropertyName.ScaleX,
 		timelineId: "",
-		valueType: ValueType.Number,
 		value: transform.scaleX,
 		compoundPropertyId: scaleId,
 	};
@@ -114,7 +103,6 @@ export const transformPropertiesFactory = (
 		compositionId,
 		name: PropertyName.ScaleY,
 		timelineId: "",
-		valueType: ValueType.Number,
 		value: transform.scaleY,
 		compoundPropertyId: scaleId,
 	};
@@ -141,7 +129,6 @@ export const transformPropertiesFactory = (
 			compositionId,
 			name: PropertyName.Rotation,
 			timelineId: "",
-			valueType: ValueType.Number,
 			value: transform.rotation,
 			compoundPropertyId: "",
 		},
@@ -152,7 +139,6 @@ export const transformPropertiesFactory = (
 			compositionId,
 			name: PropertyName.Opacity,
 			timelineId: "",
-			valueType: ValueType.Number,
 			value: 1,
 			compoundPropertyId: "",
 		},

--- a/src/composition/manager/compositionManager.ts
+++ b/src/composition/manager/compositionManager.ts
@@ -203,8 +203,7 @@ export const manageTopLevelComposition = (
 	app.stage.addChild(compContainer);
 	app.stage.addChild(interactionContainer);
 
-	const diffToken = subscribeToDiffs((diffs, direction) => {
-		const actionState = getActionState();
+	const diffToken = subscribeToDiffs((actionState, diffs, direction) => {
 		ctx.onDiffs(actionState, diffs, direction);
 
 		for (const diff of diffs) {

--- a/src/flow/nodes/property/PropertyInputNode.tsx
+++ b/src/flow/nodes/property/PropertyInputNode.tsx
@@ -12,6 +12,7 @@ import { nodeHandlers } from "~/flow/nodes/nodeHandlers";
 import { PropertyNodeSelectProperty } from "~/flow/nodes/property/PropertyNodeSelectProperty";
 import { flowActions } from "~/flow/state/flowActions";
 import { requestAction } from "~/listener/requestAction";
+import { getPropertyValueType } from "~/property/propertyConstants";
 import { connectActionState, getActionState } from "~/state/stateUtils";
 import { ValueType } from "~/types";
 import { compileStylesheetLabelled } from "~/util/stylesheets";
@@ -105,7 +106,7 @@ function PropertyInputNodeComponent(props: Props) {
 
 					return {
 						name: getLayerPropertyLabel(property.name),
-						type: property.valueType,
+						type: getPropertyValueType(property.name),
 					};
 				});
 

--- a/src/flow/nodes/property/PropertyOutputNode.tsx
+++ b/src/flow/nodes/property/PropertyOutputNode.tsx
@@ -13,6 +13,7 @@ import { PropertyNodeSelectProperty } from "~/flow/nodes/property/PropertyNodeSe
 import { flowActions } from "~/flow/state/flowActions";
 import { useMemoActionState } from "~/hook/useActionState";
 import { requestAction } from "~/listener/requestAction";
+import { getPropertyValueType } from "~/property/propertyConstants";
 import { connectActionState, getActionState } from "~/state/stateUtils";
 import { PropertyGroupName, ValueType } from "~/types";
 import { separateLeftRightMouse } from "~/util/mouse";
@@ -85,7 +86,7 @@ function PropertyOutputNodeComponent(props: Props) {
 
 					return {
 						name: getLayerPropertyLabel(property.name),
-						type: property.valueType,
+						type: getPropertyValueType(property.name),
 						pointer: null,
 						value: null,
 					};

--- a/src/graphEditor/GraphEditor.tsx
+++ b/src/graphEditor/GraphEditor.tsx
@@ -2,13 +2,14 @@ import React, { useRef } from "react";
 import { CompoundProperty } from "~/composition/compositionTypes";
 import { reduceCompProperties } from "~/composition/compositionUtils";
 import { compSelectionFromState } from "~/composition/util/compSelectionUtils";
-import { AreaType, TimelineColors } from "~/constants";
+import { AreaType } from "~/constants";
 import { cssVariables } from "~/cssVariables";
 import { openGraphEditorContextMenu } from "~/graphEditor/graphEditorContextMenu";
 import { graphEditorHandlers } from "~/graphEditor/graphEditorHandlers";
 import { renderGraphEditor } from "~/graphEditor/renderGraphEditor";
 import { useGraphEditorCursor } from "~/graphEditor/useGraphEditorCursor";
 import { useTickedRendering } from "~/hook/useTickedRendering";
+import { getPropertyTimelineColor } from "~/property/propertyConstants";
 import { getActionState, getAreaActionState } from "~/state/stateUtils";
 import {
 	applyTimelineIndexAndValueShifts,
@@ -85,8 +86,9 @@ export const GraphEditor: React.FC<Props> = (props) => {
 								compositionSelection.properties[compoundProperty.id])
 						) {
 							acc.timelineIds.push(property.timelineId);
-							acc.colors[property.timelineId] =
-								property.color || TimelineColors.XPosition;
+							acc.colors[property.timelineId] = getPropertyTimelineColor(
+								property.name,
+							);
 						}
 
 						return acc;

--- a/src/listener/diffListener.ts
+++ b/src/listener/diffListener.ts
@@ -1,13 +1,14 @@
 import { Diff } from "~/diff/diffs";
 
-const diffSubscribers: Array<{
-	id: string;
-	fn: (diffs: Diff[], direction: "forward" | "backward") => void;
-}> = [];
+type SubscribeFn = (
+	actionState: ActionState,
+	diffs: Diff[],
+	direction: "forward" | "backward",
+) => void;
 
-export const subscribeToDiffs = (
-	fn: (diffs: Diff[], direction: "forward" | "backward") => void,
-): string => {
+const diffSubscribers: Array<{ id: string; fn: SubscribeFn }> = [];
+
+export const subscribeToDiffs = (fn: SubscribeFn): string => {
 	const id = (Math.max(0, ...diffSubscribers.map((item) => parseInt(item.id))) + 1).toString();
 	diffSubscribers.push({ id, fn });
 	return id;
@@ -23,10 +24,11 @@ export const unsubscribeToDiffs = (id: string) => {
 };
 
 export const sendDiffsToSubscribers = (
+	actionState: ActionState,
 	diffs: Diff[],
 	direction: "forward" | "backward" = "forward",
 ) => {
 	for (const { fn } of diffSubscribers) {
-		fn(diffs, direction);
+		fn(actionState, diffs, direction);
 	}
 };

--- a/src/listener/requestAction.ts
+++ b/src/listener/requestAction.ts
@@ -89,7 +89,7 @@ const performRequestedAction = (
 		onComplete();
 
 		const diffsToPerform = reverseDiffs.length ? reverseDiffs : [...allDiffs].reverse();
-		sendDiffsToSubscribers(diffsToPerform, "backward");
+		sendDiffsToSubscribers(getActionState(), diffsToPerform, "backward");
 	};
 
 	store.dispatch(historyActions.startAction(actionId));
@@ -166,7 +166,7 @@ const performRequestedAction = (
 			}
 
 			if (diffs.length) {
-				sendDiffsToSubscribers(diffs);
+				sendDiffsToSubscribers(getActionState(), diffs);
 			}
 
 			const modifiedKeys: string[] = [];
@@ -227,7 +227,7 @@ const performRequestedAction = (
 			const result = fn(diffFactory);
 			const diffsToPerform = Array.isArray(result) ? result : [result];
 			allDiffs.push(...diffsToPerform);
-			sendDiffsToSubscribers(diffsToPerform);
+			sendDiffsToSubscribers(getActionState(), diffsToPerform);
 		},
 
 		addReverseDiff: (fn) => {

--- a/src/property/propertyConstants.ts
+++ b/src/property/propertyConstants.ts
@@ -1,4 +1,4 @@
-import { PropertyName, ValueFormat } from "~/types";
+import { PropertyName, ValueFormat, ValueType } from "~/types";
 
 const propertyNameToMinValue: Partial<Record<string, number>> = {
 	[PropertyName.Width]: 0,
@@ -41,4 +41,41 @@ const propertyNameToTimelineColor: Partial<Record<string, string>> = {
 
 export function getPropertyTimelineColor(propertyName: PropertyName): string {
 	return propertyNameToTimelineColor[propertyName] || "#ffffff";
+}
+
+const propertyNameToValueType: Partial<Record<string, ValueType>> = {
+	[PropertyName.AnchorX]: ValueType.Number,
+	[PropertyName.AnchorY]: ValueType.Number,
+	[PropertyName.ArrayModifier_Count]: ValueType.Number,
+	[PropertyName.ArrayModifier_OriginBehavior]: ValueType.OriginBehavior,
+	[PropertyName.ArrayModifier_OriginX]: ValueType.Number,
+	[PropertyName.ArrayModifier_OriginY]: ValueType.Number,
+	[PropertyName.ArrayModifier_RotationCorrection]: ValueType.Number,
+	[PropertyName.ArrayModifier_TransformBehavior]: ValueType.TransformBehavior,
+	[PropertyName.BorderRadius]: ValueType.Number,
+	[PropertyName.Fill]: ValueType.RGBAColor,
+	[PropertyName.FillRule]: ValueType.FillRule,
+	[PropertyName.Height]: ValueType.Number,
+	[PropertyName.InnerRadius]: ValueType.Number,
+	[PropertyName.LineCap]: ValueType.LineCap,
+	[PropertyName.LineJoin]: ValueType.LineJoin,
+	[PropertyName.MiterLimit]: ValueType.Number,
+	[PropertyName.Opacity]: ValueType.Number,
+	[PropertyName.OuterRadius]: ValueType.Number,
+	[PropertyName.PositionX]: ValueType.Number,
+	[PropertyName.PositionY]: ValueType.Number,
+	[PropertyName.RGBAColor]: ValueType.RGBAColor,
+	[PropertyName.RGBColor]: ValueType.RGBColor,
+	[PropertyName.Rotation]: ValueType.Number,
+	[PropertyName.Scale]: ValueType.Number,
+	[PropertyName.ScaleX]: ValueType.Number,
+	[PropertyName.ScaleY]: ValueType.Number,
+	[PropertyName.ShapeLayer_Path]: ValueType.Path,
+	[PropertyName.StrokeColor]: ValueType.RGBAColor,
+	[PropertyName.StrokeWidth]: ValueType.Number,
+	[PropertyName.Width]: ValueType.Number,
+};
+
+export function getPropertyValueType(propertyName: PropertyName): ValueType {
+	return propertyNameToValueType[propertyName] || ValueType.Any;
 }

--- a/src/property/propertyConstants.ts
+++ b/src/property/propertyConstants.ts
@@ -1,0 +1,44 @@
+import { PropertyName, ValueFormat } from "~/types";
+
+const propertyNameToMinValue: Partial<Record<string, number>> = {
+	[PropertyName.Width]: 0,
+	[PropertyName.Height]: 0,
+	[PropertyName.InnerRadius]: 0,
+	[PropertyName.OuterRadius]: 0,
+	[PropertyName.StrokeWidth]: 0,
+	[PropertyName.BorderRadius]: 0,
+	[PropertyName.Opacity]: 0,
+	[PropertyName.MiterLimit]: 1,
+};
+
+const propertyNameToMaxValue: Partial<Record<string, number>> = {
+	[PropertyName.Opacity]: 1,
+};
+
+export function getPropertyMinValue(propertyName: PropertyName): number | undefined {
+	return propertyNameToMinValue[propertyName];
+}
+
+export function getPropertyMaxValue(propertyName: PropertyName): number | undefined {
+	return propertyNameToMaxValue[propertyName];
+}
+
+const propertyNameToValueFormat: Partial<Record<string, ValueFormat>> = {
+	[PropertyName.Opacity]: ValueFormat.Percentage,
+	[PropertyName.Rotation]: ValueFormat.Rotation,
+};
+
+export function getPropertyValueFormat(propertyName: PropertyName): number | undefined {
+	return propertyNameToValueFormat[propertyName];
+}
+
+const propertyNameToTimelineColor: Partial<Record<string, string>> = {
+	[PropertyName.PositionX]: "#FF3434",
+	[PropertyName.PositionY]: "#5BE719",
+	[PropertyName.Width]: "#32E8E8",
+	[PropertyName.Height]: "#EE30F2",
+};
+
+export function getPropertyTimelineColor(propertyName: PropertyName): string {
+	return propertyNameToTimelineColor[propertyName] || "#ffffff";
+}

--- a/src/state/createApplicationStateFromActionState.ts
+++ b/src/state/createApplicationStateFromActionState.ts
@@ -1,0 +1,52 @@
+import { ActionBasedState } from "~/state/history/actionBasedReducer";
+import { HistoryState } from "~/state/history/historyReducer";
+
+export const createApplicationStateFromActionState = (
+	actionState: ActionState,
+): ApplicationState => {
+	const toActionBasedState = <S extends {} = {}>(state: S): ActionBasedState<S> => ({
+		action: null,
+		state,
+	});
+	const toHistoryBasedState = <S extends {} = {}>(
+		state: S,
+		type: "selection" | "normal" = "normal",
+	): HistoryState<S> => ({
+		action: null,
+		index: 0,
+		indexDirection: 1,
+		list: [
+			{
+				state,
+				modifiedRelated: false,
+				name: "Initial state",
+				allowIndexShift: false,
+				diffs: [],
+			},
+		],
+		type,
+	});
+
+	const state: ApplicationState = {
+		area: toActionBasedState(actionState.area),
+		compositionSelectionState: toHistoryBasedState(
+			actionState.compositionSelectionState,
+			"selection",
+		),
+		compositionState: toHistoryBasedState(actionState.compositionState),
+		contextMenu: toActionBasedState(actionState.contextMenu),
+		flowState: toHistoryBasedState(actionState.flowState),
+		flowSelectionState: toHistoryBasedState(actionState.flowSelectionState, "selection"),
+		project: toHistoryBasedState(actionState.project),
+		shapeState: toHistoryBasedState(actionState.shapeState),
+		shapeSelectionState: toHistoryBasedState(actionState.shapeSelectionState, "selection"),
+		timelineState: toHistoryBasedState(actionState.timelineState),
+		timelineSelectionState: toHistoryBasedState(
+			actionState.timelineSelectionState,
+			"selection",
+		),
+		tool: toActionBasedState(actionState.tool),
+	};
+
+	return state;
+};

--- a/src/state/stateUtils.ts
+++ b/src/state/stateUtils.ts
@@ -1,6 +1,5 @@
 import { connect, DispatchProp, InferableComponentEnhancerWithProps } from "react-redux";
 import { AreaType } from "~/constants";
-import { ActionBasedState } from "~/state/history/actionBasedReducer";
 import { HistoryState } from "~/state/history/historyReducer";
 import { store } from "~/state/store";
 import { AreaState } from "~/types/areaTypes";
@@ -28,7 +27,10 @@ const getCurrentStateFromApplicationState = (_state: ApplicationState): ActionSt
 	return actionState;
 };
 
-export const getActionStateFromApplicationState = (_state: ApplicationState): ActionState => {
+export const getActionStateFromApplicationState = (
+	_state: ApplicationState,
+	index?: number,
+): ActionState => {
 	const state: any = _state;
 	const keys = Object.keys(state) as Array<keyof ApplicationState>;
 	const actionState = keys.reduce<ActionState>((obj, key) => {
@@ -37,12 +39,13 @@ export const getActionStateFromApplicationState = (_state: ApplicationState): Ac
 		} else if (state[key].list) {
 			const s = state[key] as HistoryState<any>;
 			const shiftForward =
+				typeof index === "undefined" &&
 				s.type === "selection" &&
 				s.indexDirection === -1 &&
 				s.list[s.index + 1].modifiedRelated &&
 				s.list[s.index + 1].allowIndexShift;
 
-			obj[key] = s.list[s.index + (shiftForward ? 1 : 0)].state;
+			obj[key] = s.list[index ?? s.index + (shiftForward ? 1 : 0)].state;
 		} else {
 			obj[key] = state[key].state;
 		}
@@ -50,56 +53,6 @@ export const getActionStateFromApplicationState = (_state: ApplicationState): Ac
 		return obj;
 	}, {} as any);
 	return actionState;
-};
-
-export const createApplicationStateFromActionState = (
-	actionState: ActionState,
-): ApplicationState => {
-	const toActionBasedState = <S extends {} = {}>(state: S): ActionBasedState<S> => ({
-		action: null,
-		state,
-	});
-	const toHistoryBasedState = <S extends {} = {}>(
-		state: S,
-		type: "selection" | "normal" = "normal",
-	): HistoryState<S> => ({
-		action: null,
-		index: 0,
-		indexDirection: 1,
-		list: [
-			{
-				state,
-				modifiedRelated: false,
-				name: "Initial state",
-				allowIndexShift: false,
-				diffs: [],
-			},
-		],
-		type,
-	});
-
-	const state: ApplicationState = {
-		area: toActionBasedState(actionState.area),
-		compositionSelectionState: toHistoryBasedState(
-			actionState.compositionSelectionState,
-			"selection",
-		),
-		compositionState: toHistoryBasedState(actionState.compositionState),
-		contextMenu: toActionBasedState(actionState.contextMenu),
-		flowState: toHistoryBasedState(actionState.flowState),
-		flowSelectionState: toHistoryBasedState(actionState.flowSelectionState, "selection"),
-		project: toHistoryBasedState(actionState.project),
-		shapeState: toHistoryBasedState(actionState.shapeState),
-		shapeSelectionState: toHistoryBasedState(actionState.shapeSelectionState, "selection"),
-		timelineState: toHistoryBasedState(actionState.timelineState),
-		timelineSelectionState: toHistoryBasedState(
-			actionState.timelineSelectionState,
-			"selection",
-		),
-		tool: toActionBasedState(actionState.tool),
-	};
-
-	return state;
 };
 
 export function connectActionState<TStateProps = {}, TOwnProps = {}>(

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -1,7 +1,7 @@
 import { createStore, Store } from "redux";
+import { createApplicationStateFromActionState } from "~/state/createApplicationStateFromActionState";
 import reducers from "~/state/reducers";
 import { getSavedActionState } from "~/state/saveState";
-import { createApplicationStateFromActionState } from "~/state/stateUtils";
 
 let initialState: ApplicationState | undefined;
 

--- a/src/timeline/context/TimelineValueContext.tsx
+++ b/src/timeline/context/TimelineValueContext.tsx
@@ -26,8 +26,7 @@ export const TimelinePropertyStoreProvider: React.FC<Props> = (props) => {
 	}
 
 	useEffect(() => {
-		const id = subscribeToDiffs((diffs, direction) => {
-			const actionState = getActionState();
+		const id = subscribeToDiffs((actionState, diffs, direction) => {
 			propertyManagerDiffHandler(
 				compositionId,
 				propertyManager,

--- a/src/timeline/property/TimelineProperty.tsx
+++ b/src/timeline/property/TimelineProperty.tsx
@@ -12,6 +12,7 @@ import {
 } from "~/composition/util/compositionPropertyUtils";
 import { compSelectionFromState } from "~/composition/util/compSelectionUtils";
 import { requestAction } from "~/listener/requestAction";
+import { getPropertyValueType } from "~/property/propertyConstants";
 import { connectActionState } from "~/state/stateUtils";
 import styles from "~/timeline/property/TimelineProperty.styles";
 import { createTimelineContextMenu } from "~/timeline/timelineContextMenu";
@@ -267,6 +268,8 @@ const TimelineLayerPropertyComponent: React.FC<Props> = (props) => {
 		);
 	}
 
+	const valueType = getPropertyValueType(property.name);
+
 	return (
 		<div
 			className={s("container")}
@@ -281,8 +284,7 @@ const TimelineLayerPropertyComponent: React.FC<Props> = (props) => {
 							timelineHandlers.onPropertyKeyframeIconMouseDown(e, property.id),
 					})}
 					style={
-						property.valueType === ValueType.RGBAColor ||
-						property.valueType === ValueType.RGBColor
+						valueType === ValueType.RGBAColor || valueType === ValueType.RGBColor
 							? { pointerEvents: "none", opacity: "0" }
 							: {}
 					}

--- a/src/timeline/value/TimelineColorValue.tsx
+++ b/src/timeline/value/TimelineColorValue.tsx
@@ -107,6 +107,10 @@ export const TimelinePropertyColorValue: React.FC<ColorProps> = (props) => {
 		});
 	};
 
+	if (!value) {
+		return null;
+	}
+
 	return (
 		<div className={s("value")}>
 			<button

--- a/src/timeline/value/TimelineNumberValue.tsx
+++ b/src/timeline/value/TimelineNumberValue.tsx
@@ -5,6 +5,7 @@ import { compositionActions } from "~/composition/compositionReducer";
 import { Composition, CompoundProperty, Property } from "~/composition/compositionTypes";
 import { DiffFactoryFn } from "~/diff/diffFactory";
 import { requestAction, RequestActionParams } from "~/listener/requestAction";
+import { getPropertyMaxValue, getPropertyMinValue } from "~/property/propertyConstants";
 import { createOperation } from "~/state/operation";
 import { connectActionState, getActionState } from "~/state/stateUtils";
 import TimelinePropertyStyles from "~/timeline/property/TimelineProperty.styles";
@@ -232,8 +233,8 @@ const TimelineNumberValueComponent: React.FC<Props> = (props) => {
 					</button>
 				)}
 			<NumberInput
-				min={property.min}
-				max={property.max}
+				min={getPropertyMinValue(property.name)}
+				max={getPropertyMaxValue(property.name)}
 				onChange={onValueChange}
 				onChangeEnd={onValueChangeEnd}
 				value={props.rawValue}

--- a/src/timeline/value/TimelineValue.tsx
+++ b/src/timeline/value/TimelineValue.tsx
@@ -1,5 +1,6 @@
 import React, { useContext, useEffect, useState } from "react";
 import { Property } from "~/composition/compositionTypes";
+import { getPropertyValueType } from "~/property/propertyConstants";
 import { connectActionState } from "~/state/stateUtils";
 import { TimelinePropertyStoreContext } from "~/timeline/context/TimelineValueContext";
 import { TimelinePropertyColorValue } from "~/timeline/value/TimelineColorValue";
@@ -125,7 +126,7 @@ const mapState: MapActionState<StateProps, OwnProps> = (
 	{ compositionState: compositions },
 	{ propertyId },
 ) => ({
-	valueType: (compositions.properties[propertyId] as Property).valueType,
+	valueType: getPropertyValueType((compositions.properties[propertyId] as Property).name),
 });
 
 export const TimelineValue = connectActionState(mapState)(TimelineValueComponent);


### PR DESCRIPTION
Remove `valueType`, `color`, `min` and `max` from the `Property` interface.

All of these can be determined via a `Record<PropertyName, Whatever>` map. Storing these within the `CompositionState` is completely unnecessary.

Also fixes a problem with diffs where the state would not be updated before diffs are sent to subscribers.

Consider:

```tsx
store.dispatch(historyActions.moveHistoryIndex(index - 1));
sendDiffsToSubscribers(diffs, "backward");
```

Since `store.dispatch` triggers a synchronous render, the diffs will not be sent before React components rerender. If any React components depend on state computed via diffs, that state will not be computed at mount time.

But if we call `sendDiffsToSubscribers(diffs, "backward");` first, it will not be computed with the correct state.

To get around this, `sendDiffsToSubscribers` now receives `actionState` as an argument. The example now looks like so:

```tsx
store.dispatch(historyActions.moveHistoryIndex(index - 1));
sendDiffsToSubscribers(actionState, diffs, "backward");
```

We could also solve this inside of the `sendDiffsToSubscribers` fn when `direction === "backwards"`, but this solution feels more explicit.