### PR TITLE
Various Graph Bug Fixes

### DIFF
--- a/src/composition/manager/layer/layerManagerDiffHandler.ts
+++ b/src/composition/manager/layer/layerManagerDiffHandler.ts
@@ -13,7 +13,6 @@ import {
 	ModifyMultipleLayerPropertiesDiff,
 	ModifyPropertyDiff,
 	PropertyStructureDiff,
-	RemoveFlowNodeDiff,
 	RemoveLayerDiff,
 	TogglePropertyAnimatedDiff,
 	UpdateNodeConnectionDiff,
@@ -54,8 +53,8 @@ export const layerManagerDiffHandler = (
 		}
 	};
 
-	const nodeDoesNotAffectComposition = (nodeId: string) => {
-		return compositionId !== getFlowNodeAssociatedCompositionId(nodeId, actionState);
+	const nodeDoesNotAffectComposition = (nodeId: string, state = actionState) => {
+		return compositionId !== getFlowNodeAssociatedCompositionId(nodeId, state);
 	};
 	const propertyDoesNotAffectComposition = (propertyId: string) => {
 		const property = actionState.compositionState.properties[propertyId];
@@ -87,15 +86,6 @@ export const layerManagerDiffHandler = (
 		},
 		[DiffType.RemoveLayer]: (diff: RemoveLayerDiff) => {
 			onAddLayers(diff.layerIds);
-		},
-		[DiffType.RemoveFlowNode]: (diff: RemoveFlowNodeDiff) => {
-			const { nodeId } = diff;
-
-			if (nodeDoesNotAffectComposition(nodeId)) {
-				return;
-			}
-
-			performChange({ nodeIds: [nodeId] });
 		},
 	};
 
@@ -136,17 +126,6 @@ export const layerManagerDiffHandler = (
 		},
 		[DiffType.AddFlowNode]: (_diff: AddFlowNodeDiff) => {
 			// See comment in propertyManagerDiffHandler
-		},
-		[DiffType.RemoveFlowNode]: (diff: RemoveFlowNodeDiff) => {
-			const { nodeId } = diff;
-			const { flowState } = prevState;
-			const { graphId } = flowState.nodes[nodeId];
-			const { layerId } = flowState.graphs[graphId];
-
-			if (layerDoesNotAffectComposition(layerId)) {
-				return;
-			}
-			performChange({ nodeIds: [nodeId] });
 		},
 		[DiffType.UpdateNodeConnection]: (diff: UpdateNodeConnectionDiff) => {
 			const { nodeIds } = diff;

--- a/src/composition/manager/property/propertyManager.ts
+++ b/src/composition/manager/property/propertyManager.ts
@@ -213,7 +213,7 @@ export const createPropertyManager = (
 				propertyIds.push(
 					...getPropertyIdsAffectedByNodes(
 						actionState,
-						layerGraphs.nodeIdsThatEmitFrameIndex,
+						options.nodeIds,
 						layerGraphs.nodeToNext,
 					),
 				);

--- a/src/composition/manager/property/propertyStore.ts
+++ b/src/composition/manager/property/propertyStore.ts
@@ -51,6 +51,7 @@ export class PropertyStore {
 	public reset(actionState: ActionState, compositionId: string) {
 		this.rawValues = computeValueByPropertyIdForComposition(actionState, compositionId);
 		this.computedValues = {};
+		this.computedValueArrays = {};
 	}
 	public addListener(propertyId: string, fn: ListenerFn) {
 		if (!this.listenersByPropertyId[propertyId]) {

--- a/src/composition/property/getPropertyIdsAffectedByNodes.ts
+++ b/src/composition/property/getPropertyIdsAffectedByNodes.ts
@@ -4,7 +4,7 @@ import { getFlowPropertyNodeReferencedPropertyIds } from "~/flow/flowUtils";
 
 export function getPropertyIdsAffectedByNodes(
 	actionState: ActionState,
-	nodeIdsThatEmitFrameIndex: string[],
+	nodeIds: string[],
 	nodeToNext: Record<string, string[]>,
 ): string[] {
 	const found = new Set<string>();
@@ -30,7 +30,7 @@ export function getPropertyIdsAffectedByNodes(
 			propertyIds.forEach((propertyId) => propertyIdSet.add(propertyId));
 		}
 	}
-	for (const nodeId of nodeIdsThatEmitFrameIndex) {
+	for (const nodeId of nodeIds) {
 		dfs(nodeId);
 	}
 	return [...propertyIdSet];

--- a/src/composition/property/layerGraphNodeOutputs.ts
+++ b/src/composition/property/layerGraphNodeOutputs.ts
@@ -94,6 +94,7 @@ export const getLayerGraphNodeOutputs = (
 					: arrayModifierGraphNodeOutputMap[input.pointer.nodeId][
 							options.arrayModifierIndex
 					  ];
+
 			return outputs[input.pointer.outputIndex];
 		}
 		return { type: input.type, value: input.value };

--- a/src/diff/diffFactory.ts
+++ b/src/diff/diffFactory.ts
@@ -42,9 +42,6 @@ export const diffFactory = {
 	flowNodeExpression: (nodeId: string): Diff => {
 		return { type: DiffType.FlowNodeExpression, nodeId };
 	},
-	removeFlowNode: (nodeId: string): Diff => {
-		return { type: DiffType.RemoveFlowNode, nodeId };
-	},
 	addFlowNode: (nodeId: string): Diff => {
 		return { type: DiffType.AddFlowNode, nodeId };
 	},

--- a/src/diff/diffs.ts
+++ b/src/diff/diffs.ts
@@ -22,7 +22,6 @@ export enum DiffType {
 	ModifyMultipleLayerProperties = 13,
 	FlowNodeState = 14,
 	FlowNodeExpression = 15,
-	RemoveFlowNode = 16,
 	UpdateNodeConnection = 17,
 	AddFlowNode = 18,
 	LayerParent = 19,
@@ -104,11 +103,6 @@ export interface FlowNodeExpressionDiff {
 	nodeId: string;
 }
 
-export interface RemoveFlowNodeDiff {
-	type: DiffType.RemoveFlowNode;
-	nodeId: string;
-}
-
 export interface AddFlowNodeDiff {
 	type: DiffType.AddFlowNode;
 	nodeId: string;
@@ -171,7 +165,6 @@ export type Diff =
 	| ModifyMultipleLayerPropertiesDiff
 	| FlowNodeStateDiff
 	| FlowNodeExpressionDiff
-	| RemoveFlowNodeDiff
 	| AddFlowNodeDiff
 	| UpdateNodeConnectionDiff
 	| LayerParentDiff

--- a/src/flow/flowEditorKeyboardShortcuts.ts
+++ b/src/flow/flowEditorKeyboardShortcuts.ts
@@ -13,7 +13,7 @@ const flowShortcuts = {
 		const op = createOperation(params);
 		const { graphId } = getAreaActionState(areaId);
 		flowOperations.removeSelectedNodesInGraph(op, graphId);
-		params.dispatch(op.actions);
+		op.submit();
 	},
 };
 

--- a/src/flow/graph/graphOutputNodes.ts
+++ b/src/flow/graph/graphOutputNodes.ts
@@ -8,6 +8,7 @@ export const findGraphOutputNodes = (
 	const nodeIds = graph.nodes;
 
 	const outputNodes: FlowNode<FlowNodeType.property_output>[] = [];
+
 	for (const nodeId of nodeIds) {
 		const node = flowState.nodes[nodeId];
 		if (node.type === FlowNodeType.property_output) {

--- a/src/flow/nodes/nodeHandlers.ts
+++ b/src/flow/nodes/nodeHandlers.ts
@@ -2,6 +2,7 @@ import { getAreaViewport } from "~/area/util/getAreaViewport";
 import { AreaType, FLOW_NODE_MIN_WIDTH } from "~/constants";
 import { contextMenuActions } from "~/contextMenu/contextMenuActions";
 import { flowValidInputsToOutputsMap } from "~/flow/flowIO";
+import { flowOperations } from "~/flow/flowOperations";
 import {
 	didFlowSelectionChange,
 	flowEditorGlobalToNormal,
@@ -16,6 +17,7 @@ import {
 } from "~/flow/util/flowNodeHeight";
 import { isKeyDown } from "~/listener/keyboard";
 import { requestAction, RequestActionCallback } from "~/listener/requestAction";
+import { createOperation } from "~/state/operation";
 import { getActionState, getAreaActionState } from "~/state/stateUtils";
 import { getDistance } from "~/util/math";
 
@@ -80,7 +82,7 @@ const getAllOutputsOfType = (flowState: FlowState, nodeId: string, inputIndex: n
 };
 
 export const nodeHandlers = {
-	onRightClick: (e: React.MouseEvent, graphId: string, nodeId: string) => {
+	onRightClick: (e: React.MouseEvent, graphId: string, _nodeId: string) => {
 		requestAction({ history: true }, (params) => {
 			params.dispatch(
 				contextMenuActions.openContextMenu(
@@ -89,12 +91,12 @@ export const nodeHandlers = {
 						{
 							label: "Delete node",
 							onSelect: () => {
-								params.dispatch(
-									contextMenuActions.closeContextMenu(),
-									flowActions.removeNode(graphId, nodeId),
-								);
-								params.addDiff((diff) => diff.removeFlowNode(nodeId));
-								params.submitAction("Remove node");
+								const op = createOperation(params);
+								flowOperations.removeSelectedNodesInGraph(op, graphId);
+								op.submit();
+
+								params.dispatch(contextMenuActions.closeContextMenu());
+								params.submitAction("Remove selected nodes");
 							},
 							default: true,
 						},


### PR DESCRIPTION
# Changes

## Recompute Array Modifier Graphs on Count update

This comment explains the reasoning reasonably well:

```tsx
// When the count of an array modifier updates, every single node in the
// respective array modifier graph must be updated.
//
// This is because we currently compute every node N times and store the
// results in a `Record<string, any[]>`.
//
// Optimally, we would only store a list of N values for the nodes who are
// downstream from an `array_modifier_index` nodes. Other nodes do not need
// to be computed more than once.
propertyIdToAffectedInputNodes[countId] = [...graph.nodes];
```


## Remove `RemoveFlowNode` diff type

It seems like all add/remove diffs are causing problems due to the prev vs current state problem. Finding out whether a certain `nodeId` affects a given composition depending on looking up that node in `FlowState` and checking its `graphId` etc. For that lookup we need to have to correct state (prev or current). The boilerplate around that is more significant than I would like.

To get around this, we can just remove the `RemoveFlowNode` diff type and replace its usage with `PropertyStructure`.


## Continue preferring operations

I'm finding the "operation" abstraction to be useful. I expect us to use it more and more.