### PR TITLE
Make Operation Actions Private

### DIFF
--- a/src/graphEditor/graphEditorContextMenu.ts
+++ b/src/graphEditor/graphEditorContextMenu.ts
@@ -27,7 +27,7 @@ export const openGraphEditorContextMenu = (position: Vec2, opts: Options) => {
 				default: true,
 				onSelect: () => {
 					timelineOperations.removeSelectedKeyframes(op, timelineIds, compositionId);
-					params.dispatch(op.actions);
+					op.submit();
 					params.submitAction("Remove selected keyframes");
 				},
 			});

--- a/src/graphEditor/graphEditorHandlers.ts
+++ b/src/graphEditor/graphEditorHandlers.ts
@@ -129,7 +129,7 @@ export const graphEditorHandlers = {
 						timelineAreaActions.setFields({ dragSelectRect: null }),
 					),
 				);
-				params.dispatch(op.actions);
+				op.submit();
 				params.submitAction("Select keyframes");
 			},
 		});
@@ -287,7 +287,7 @@ export const graphEditorHandlers = {
 							null,
 						),
 					);
-					params.dispatch(op.actions);
+					op.submit();
 					params.submitAction("Remove control point");
 					return;
 				} else {
@@ -300,7 +300,7 @@ export const graphEditorHandlers = {
 					);
 				}
 
-				params.dispatch(op.actions);
+				op.submit();
 				params.submitAction("Move control point");
 			},
 		});
@@ -349,7 +349,7 @@ export const graphEditorHandlers = {
 					),
 				);
 
-				params.dispatch(op.actions);
+				op.submit();
 			},
 			tickShouldUpdate: ({ mousePosition }) => {
 				const [yUpper, yLower] = getYUpperLower(viewport, mousePosition.global);
@@ -389,7 +389,7 @@ export const graphEditorHandlers = {
 						valueShift,
 					}),
 				);
-				params.dispatch(op.actions);
+				op.submit();
 			},
 			mouseUp: (params, hasMoved) => {
 				const op = createOperation(params);
@@ -410,7 +410,7 @@ export const graphEditorHandlers = {
 							null,
 						),
 					);
-					params.dispatch(op.actions);
+					op.submit();
 					params.submitAction("Remove keyframe control points");
 					return;
 				}
@@ -425,7 +425,7 @@ export const graphEditorHandlers = {
 					op.add(timelineActions.applyControlPointShift(id, selection));
 				});
 
-				params.dispatch(op.actions);
+				op.submit();
 				params.submitAction("Create control points");
 			},
 		});

--- a/src/state/operation.ts
+++ b/src/state/operation.ts
@@ -1,30 +1,31 @@
 import { DiffFactoryFn } from "~/diff/diffFactory";
 import { RequestActionParams } from "~/listener/requestAction";
 import { getActionState } from "~/state/stateUtils";
-import { Operation } from "~/types";
+import { Action, Operation } from "~/types";
 
 export const createOperation = (params: RequestActionParams): Operation => {
 	const diffsToAdd: DiffFactoryFn[] = [];
 	const diffsToPerform: DiffFactoryFn[] = [];
 
+	const actions: Action[] = [];
+
 	const self: Operation = {
-		actions: [],
 		add: (..._actions) => {
-			self.actions.push(..._actions);
+			actions.push(..._actions);
 		},
 		clear: () => {
-			self.actions.length = 0;
+			actions.length = 0;
+			diffsToAdd.length = 0;
+			diffsToPerform.length = 0;
 		},
 		addDiff: (fn) => diffsToAdd.push(fn),
 		performDiff: (fn) => diffsToPerform.push(fn),
 		submit: () => {
-			params.dispatch(self.actions);
+			params.dispatch(actions);
 			diffsToPerform.forEach(params.performDiff);
 			diffsToAdd.forEach((diff) => params.addDiff(diff));
 			self.state = getActionState();
-			self.actions.length = 0;
-			diffsToAdd.length = 0;
-			diffsToPerform.length = 0;
+			self.clear();
 		},
 		state: getActionState(),
 	};

--- a/src/svg/composition/svgLayerFactory.ts
+++ b/src/svg/composition/svgLayerFactory.ts
@@ -126,7 +126,7 @@ function g(ctx: CompositionFromSvgContext, _node: SVGNode) {
 			svgLayerFactory[child.tagName]!(ctx, child);
 		}
 
-		ctx.params.dispatch(ctx.op.actions);
+		ctx.op.submit();
 		ctx.op.clear();
 		ctx.compositionState = getActionState().compositionState;
 	}

--- a/src/timeline/layer/TimelineLayerParent.tsx
+++ b/src/timeline/layer/TimelineLayerParent.tsx
@@ -71,7 +71,7 @@ const TimelineLayerParentComponent: React.FC<Props> = (props) => {
 	const onRemoveParent = (params: RequestActionParams) => {
 		const op = createOperation(params);
 		layerOperations.removeLayerParentLayer(op, getActionState(), props.layerId);
-		params.dispatch(op.actions);
+		op.submit();
 		params.addDiff((diff) => diff.layerParent(props.layerId));
 		params.submitAction("Remove layer's parent layer");
 	};
@@ -79,7 +79,7 @@ const TimelineLayerParentComponent: React.FC<Props> = (props) => {
 	const onSelectParent = (params: RequestActionParams, parentId: string) => {
 		const op = createOperation(params);
 		layerOperations.setLayerParentLayer(op, getActionState(), props.layerId, parentId);
-		params.dispatch(op.actions);
+		op.submit();
 		params.addDiff((diff) => diff.layerParent(props.layerId));
 		params.submitAction("Set layer's parent layer");
 	};

--- a/src/timeline/layer/layerHandlers.ts
+++ b/src/timeline/layer/layerHandlers.ts
@@ -54,7 +54,7 @@ export const layerHandlers = {
 				const op = createOperation(params);
 				layerOperations.setLayerParentLayer(op, getActionState(), layerId, target.layerId);
 
-				params.dispatch(op.actions);
+				op.submit();
 				params.dispatchToAreaState(
 					areaId,
 					timelineAreaActions.setFields({

--- a/src/timeline/timelineHandlers.ts
+++ b/src/timeline/timelineHandlers.ts
@@ -920,7 +920,7 @@ export const timelineHandlers = {
 					}
 				}
 
-				params.dispatch(op.actions);
+				op.submit();
 				params.addDiff((diff) => diff.compositionSelection(property.compositionId));
 				params.submitAction("Select property");
 			},

--- a/src/timeline/timelineShortcuts.ts
+++ b/src/timeline/timelineShortcuts.ts
@@ -30,7 +30,7 @@ const timelineShortcuts = {
 		const op = createOperation(params);
 		timelineOperations.removeSelectedKeyframes(op, timelineIds, compositionId);
 
-		params.dispatch(op.actions);
+		op.submit();
 	},
 
 	easeEaseSelectedKeyframes: (areaId: string, params: RequestActionParams) => {
@@ -39,7 +39,7 @@ const timelineShortcuts = {
 		const op = createOperation(params);
 		timelineOperations.easyEaseSelectedKeyframes(op, timelineIds);
 
-		params.dispatch(op.actions);
+		op.submit();
 	},
 };
 

--- a/src/trackEditor/trackHandlers.ts
+++ b/src/trackEditor/trackHandlers.ts
@@ -205,7 +205,7 @@ const actions = {
 					}
 				}
 
-				params.dispatch(op.actions);
+				op.submit();
 			},
 			mouseMove: (params, { moveVector }) => {
 				const moveX = Math.round(moveVector.normal.x);
@@ -343,7 +343,7 @@ const actions = {
 						op.add(compositionActions.setLayerPlaybackIndex(layerId, index));
 					}
 				}
-				params.dispatch(op.actions);
+				op.submit();
 				params.performDiff((diff) =>
 					diff.frameIndex(composition.id, composition.frameIndex),
 				);
@@ -482,7 +482,7 @@ const actions = {
 						op.add(timelineActions.shiftTimelineIndex(timelineId, indexDelta));
 					}
 				}
-				params.dispatch(op.actions);
+				op.submit();
 			},
 			mouseUp: (params, hasMoved) => {
 				if (!hasMoved) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,7 +10,6 @@ export type Action = { type: string; payload: any };
 export type ToDispatch = Action[];
 
 export interface Operation {
-	actions: Action[];
 	add: (...actions: Action[]) => void;
 	clear: () => void;
 	addDiff: (fn: DiffFactoryFn) => void;


### PR DESCRIPTION
At first, `Operation` was a really simple type. It just stored `Action[]` and nothing else. Those actions would be added via:

```tsx
op.add(someAction.doThing());
```

and then submitted via:

```tsx
params.dispatch(op.actions);
```

This became problematic when `Operation` added support for diffs. If an operation fn added diffs, those would not be submitted because `params.dispatch(op.actions)` does not consider added diffs.

All usage of `params.dispatch(op.actions)` has been replaced with:

```tsx
op.submit();
```

which does consider diffs.

`op.actions` is now private.