### PR TITLE
Update How Node Right Click Works

### DIFF
--- a/src/composition/compositionShortcuts.ts
+++ b/src/composition/compositionShortcuts.ts
@@ -17,8 +17,7 @@ const compositionShortcuts = {
 
 		const op = createOperation(params);
 		timelineOperations.viewTransformProperties(op, compositionId, propertyNames);
-
-		params.dispatch(op.actions);
+		op.submit();
 	},
 
 	viewAnimatedProperties: (areaId: string, params: RequestActionParams) => {
@@ -26,8 +25,7 @@ const compositionShortcuts = {
 
 		const op = createOperation(params);
 		timelineOperations.viewAnimatedProperties(op, compositionId);
-
-		params.dispatch(op.actions);
+		op.submit();
 	},
 };
 

--- a/src/flow/flowOperations.ts
+++ b/src/flow/flowOperations.ts
@@ -3,6 +3,18 @@ import { flowActions } from "~/flow/state/flowActions";
 import { flowSelectionActions } from "~/flow/state/flowSelectionReducer";
 import { Operation } from "~/types";
 
+function selectNode(op: Operation, nodeId: string): void {
+	const { flowState, flowSelectionState } = op.state;
+	const node = flowState.nodes[nodeId];
+
+	const selection = flowSelectionFromState(node.graphId, flowSelectionState);
+
+	// If the node is selected, do nothing.
+	if (!selection.nodes[nodeId]) {
+		op.add(flowSelectionActions.setSelectedNodesInGraph(node.graphId, [nodeId]));
+	}
+}
+
 const removeSelectedNodesInGraph = (op: Operation, graphId: string): void => {
 	const { compositionState, flowState, flowSelectionState } = op.state;
 
@@ -38,6 +50,7 @@ const removeGraph = (op: Operation, graphId: string): void => {
 };
 
 export const flowOperations = {
+	selectNode,
 	removeSelectedNodesInGraph,
 	removeGraph,
 };

--- a/src/flow/nodes/nodeHandlers.ts
+++ b/src/flow/nodes/nodeHandlers.ts
@@ -17,7 +17,7 @@ import {
 } from "~/flow/util/flowNodeHeight";
 import { isKeyDown } from "~/listener/keyboard";
 import { requestAction, RequestActionCallback } from "~/listener/requestAction";
-import { createOperation } from "~/state/operation";
+import { createOperation, performOperation } from "~/state/operation";
 import { getActionState, getAreaActionState } from "~/state/stateUtils";
 import { getDistance } from "~/util/math";
 
@@ -82,14 +82,16 @@ const getAllOutputsOfType = (flowState: FlowState, nodeId: string, inputIndex: n
 };
 
 export const nodeHandlers = {
-	onRightClick: (e: React.MouseEvent, graphId: string, _nodeId: string) => {
+	onRightClick: (e: React.MouseEvent, graphId: string, nodeId: string) => {
 		requestAction({ history: true }, (params) => {
+			performOperation(params, (op) => flowOperations.selectNode(op, nodeId));
+
 			params.dispatch(
 				contextMenuActions.openContextMenu(
 					"Node",
 					[
 						{
-							label: "Delete node",
+							label: "Delete node(s)",
 							onSelect: () => {
 								const op = createOperation(params);
 								flowOperations.removeSelectedNodesInGraph(op, graphId);

--- a/src/flow/state/flowSelectionReducer.ts
+++ b/src/flow/state/flowSelectionReducer.ts
@@ -31,7 +31,7 @@ export interface FlowGraphSelection {
 }
 
 export interface FlowSelectionState {
-	[timelineId: string]: FlowGraphSelection;
+	[graphId: string]: FlowGraphSelection;
 }
 
 const _emptySelection: FlowGraphSelection = { nodes: {} };

--- a/src/state/operation.ts
+++ b/src/state/operation.ts
@@ -32,3 +32,12 @@ export const createOperation = (params: RequestActionParams): Operation => {
 
 	return self;
 };
+
+export const performOperation = (
+	params: RequestActionParams,
+	fn: (op: Operation) => void,
+): void => {
+	const op = createOperation(params);
+	fn(op);
+	op.submit();
+};

--- a/src/svg/composition/compositionFromSvg.ts
+++ b/src/svg/composition/compositionFromSvg.ts
@@ -45,8 +45,7 @@ function handleSvg(node: SVGSvgNode) {
 				svgLayerFactory[child.tagName]!(ctx, child);
 			}
 
-			params.dispatch(ctx.op.actions);
-			ctx.op.clear();
+			ctx.op.submit();
 			ctx.compositionState = getActionState().compositionState;
 		}
 


### PR DESCRIPTION
## Add two more replacements of `params.dispatch(op.actions)`

See #89. I forgot to save two files.


## Add `selectNode` to `flowOperations`

It looks like so:

```tsx
function selectNode(op: Operation, nodeId: string): void {
	const { flowState, flowSelectionState } = op.state;
	const node = flowState.nodes[nodeId];

	const selection = flowSelectionFromState(node.graphId, flowSelectionState);

	// If the node is selected, do nothing.
	if (!selection.nodes[nodeId]) {
		op.add(flowSelectionActions.setSelectedNodesInGraph(node.graphId, [nodeId]));
	}
}
```

It is performed on the right clicked node.


## Add `performOperation` util fn

It allows us to write this:

```tsx
const op = createOperation(params);
flowOperations.selectNode(op, nodeId);
op.submit();
```

like so:

```tsx
performOperation(params, (op) => flowOperations.selectNode(op, nodeId));
```

The implementation looks like so:

```tsx
export const performOperation = (
	params: RequestActionParams,
	fn: (op: Operation) => void,
): void => {
	const op = createOperation(params);
	fn(op);
	op.submit();
};
```