### PR TITLE
Refactor Flow Editor Handlers

### DIFF
--- a/__tests__/nodeEditor/flowUtils.spec.ts
+++ b/__tests__/nodeEditor/flowUtils.spec.ts
@@ -8,10 +8,7 @@ import { ValueType } from "~/types";
 
 const _graphBase: FlowGraph = {
 	_addNodeOfTypeOnClick: null,
-	_dragInputTo: null,
-	_dragOutputTo: null,
 	_dragSelectRect: null,
-	moveVector: Vec2.new(0, 0),
 	type: "layer_graph",
 	id: "0",
 	layerId: "",

--- a/src/composition/layer/layerComputePropertiesOrder.ts
+++ b/src/composition/layer/layerComputePropertiesOrder.ts
@@ -272,8 +272,8 @@ export const resolveCompositionLayerGraphs = (
 				continue;
 			}
 			arrayModifierGroupToCount[modifierGroupId] = countId;
+			const toComputeStartIndex = toCompute.length;
 			onGraphId(group.graphId);
-			const graph = flowState.graphs[group.graphId];
 
 			// When the count of an array modifier updates, every single node in the
 			// respective array modifier graph must be updated.
@@ -284,7 +284,7 @@ export const resolveCompositionLayerGraphs = (
 			// Optimally, we would only store a list of N values for the nodes who are
 			// downstream from an `array_modifier_index` nodes. Other nodes do not need
 			// to be computed more than once.
-			propertyIdToAffectedInputNodes[countId] = [...graph.nodes];
+			propertyIdToAffectedInputNodes[countId] = toCompute.slice(toComputeStartIndex);
 		}
 	}
 

--- a/src/composition/manager/property/propertyManager.ts
+++ b/src/composition/manager/property/propertyManager.ts
@@ -4,7 +4,7 @@ import { PropertyStore } from "~/composition/manager/property/propertyStore";
 import { getPropertyIdsAffectedByNodes } from "~/composition/property/getPropertyIdsAffectedByNodes";
 import {
 	computeLayerGraphNodeOutputs,
-	getLayerGraphNodeOutputs,
+	getGraphNodeOutputs,
 } from "~/composition/property/layerGraphNodeOutputs";
 import { createPropertyInfoRegistry } from "~/composition/property/propertyInfoMap";
 import { updateRawValuesForPropertyIds } from "~/composition/property/propertyRawValues";
@@ -69,7 +69,7 @@ export const createPropertyManager = (
 			const count = propertyStore.getPropertyValue(countPropertyId);
 
 			arrayModifierGraphNodeOutputMap[node.id] = Array.from({ length: count }).map((_, i) => {
-				const inputs = getLayerGraphNodeOutputs(
+				const inputs = getGraphNodeOutputs(
 					"array_modifier",
 					actionState,
 					compositionId,
@@ -92,7 +92,7 @@ export const createPropertyManager = (
 			return;
 		}
 
-		const inputs = getLayerGraphNodeOutputs(
+		const inputs = getGraphNodeOutputs(
 			"layer",
 			actionState,
 			compositionId,

--- a/src/composition/property/layerGraphNodeOutputs.ts
+++ b/src/composition/property/layerGraphNodeOutputs.ts
@@ -3,11 +3,11 @@ import { Property } from "~/composition/compositionTypes";
 import { LayerGraphsInfo } from "~/composition/layer/layerComputePropertiesOrder";
 import { PropertyStore } from "~/composition/manager/property/propertyStore";
 import { flowNodeArg } from "~/flow/flowArgs";
-import { computeNodeOutputsFromInputArgs } from "~/flow/flowComputeNodeNew";
+import { computeNodeOutputsFromInputArgs } from "~/flow/flowComputeNode";
 import { FlowNodeState } from "~/flow/flowNodeState";
 import { FlowComputeNodeArg, FlowNode, FlowNodeType } from "~/flow/flowTypes";
 
-export const getLayerGraphNodeOutputs = (
+export const getGraphNodeOutputs = (
 	type: "layer" | "array_modifier",
 	actionState: ActionState,
 	compositionId: string,

--- a/src/flow/FlowEditorConnections.tsx
+++ b/src/flow/FlowEditorConnections.tsx
@@ -33,7 +33,7 @@ class FlowEditorConnectionsComponent extends React.Component<Props> {
 	public render() {
 		const { props } = this;
 
-		const { areaState, graph, selection, width, height, left, top, nodes } = props;
+		const { areaState, graph, width, height, left, top, nodes } = props;
 		const { pan, scale } = areaState;
 		const opts = { viewport: { width, height, left, top }, pan, scale };
 
@@ -49,38 +49,6 @@ class FlowEditorConnectionsComponent extends React.Component<Props> {
 			lines.push(<line key={key} x1={p0.x} y1={p0.y} x2={p1.x} y2={p1.y} style={style} />);
 		}
 
-		if (graph._dragInputTo) {
-			const { fromInput, wouldConnectToOutput } = graph._dragInputTo;
-			const inputNode = nodes[fromInput.nodeId];
-			const inputIndex = fromInput.inputIndex;
-			const inputPos = calculateNodeInputPosition(inputNode, inputIndex).apply((vec) =>
-				flowEditorPositionToViewport(vec, opts),
-			);
-
-			let position = graph._dragInputTo.position;
-
-			if (wouldConnectToOutput) {
-				const targetNode = nodes[wouldConnectToOutput.nodeId];
-				position = calculateNodeOutputPosition(
-					targetNode,
-					wouldConnectToOutput.outputIndex,
-				);
-			}
-
-			const targetPos = flowEditorPositionToViewport(position, opts);
-
-			lines.push(
-				<line
-					key="drag-output-to"
-					x1={inputPos.x}
-					y1={inputPos.y}
-					x2={targetPos.x}
-					y2={targetPos.y}
-					style={{ stroke: COLOR, strokeWidth: LINE_WIDTH * areaState.scale }}
-				/>,
-			);
-		}
-
 		const nodeIds = graph.nodes;
 		for (let i = 0; i < nodeIds.length; i += 1) {
 			const node = nodes[nodeIds[i]];
@@ -94,17 +62,14 @@ class FlowEditorConnectionsComponent extends React.Component<Props> {
 
 				const targetNode = nodes[pointer.nodeId];
 
-				const targetPos = calculateNodeOutputPosition(targetNode, pointer.outputIndex)
-					.apply((vec) =>
-						selection.nodes[targetNode.id] ? vec.add(props.graph.moveVector) : vec,
-					)
-					.apply((vec) => flowEditorPositionToViewport(vec, opts));
+				const targetPos = calculateNodeOutputPosition(
+					targetNode,
+					pointer.outputIndex,
+				).apply((vec) => flowEditorPositionToViewport(vec, opts));
 
-				const nodePos = calculateNodeInputPosition(node, j)
-					.apply((vec) =>
-						selection.nodes[node.id] ? vec.add(props.graph.moveVector) : vec,
-					)
-					.apply((vec) => flowEditorPositionToViewport(vec, opts));
+				const nodePos = calculateNodeInputPosition(node, j).apply((vec) =>
+					flowEditorPositionToViewport(vec, opts),
+				);
 
 				lines.push(
 					<line

--- a/src/flow/FlowEditorConnections.tsx
+++ b/src/flow/FlowEditorConnections.tsx
@@ -39,34 +39,14 @@ class FlowEditorConnectionsComponent extends React.Component<Props> {
 
 		const lines: React.ReactNode[] = [];
 
-		if (graph._dragOutputTo) {
-			const { fromOutput, wouldConnectToInput } = graph._dragOutputTo;
-			const fromNode = nodes[fromOutput.nodeId];
-			const outputIndex = fromOutput.outputIndex;
-			const outputPos = flowEditorPositionToViewport(
-				calculateNodeOutputPosition(fromNode, outputIndex),
-				opts,
+		if (areaState.dragPreview) {
+			const [p0, p1] = areaState.dragPreview.map((vec) =>
+				flowEditorPositionToViewport(vec, opts),
 			);
 
-			let position = graph._dragOutputTo.position;
-
-			if (wouldConnectToInput) {
-				const targetNode = nodes[wouldConnectToInput.nodeId];
-				position = calculateNodeInputPosition(targetNode, wouldConnectToInput.inputIndex);
-			}
-
-			const targetPos = flowEditorPositionToViewport(position, opts);
-
-			lines.push(
-				<line
-					key="drag-output-to"
-					x1={outputPos.x}
-					y1={outputPos.y}
-					x2={targetPos.x}
-					y2={targetPos.y}
-					style={{ stroke: COLOR, strokeWidth: LINE_WIDTH * areaState.scale }}
-				/>,
-			);
+			const style = { stroke: COLOR, strokeWidth: LINE_WIDTH * areaState.scale };
+			const key = "dragPreviw";
+			lines.push(<line key={key} x1={p0.x} y1={p0.y} x2={p1.x} y2={p1.y} style={style} />);
 		}
 
 		if (graph._dragInputTo) {

--- a/src/flow/components/FlowNodeBody.tsx
+++ b/src/flow/components/FlowNodeBody.tsx
@@ -65,16 +65,12 @@ const mapStateToProps: MapActionState<StateProps, OwnProps> = (
 	{ flowState, flowSelectionState },
 	{ graphId, nodeId },
 ) => {
-	const graph = flowState.graphs[graphId];
 	const selection = flowSelectionFromState(graphId, flowSelectionState);
 
 	const { type, width, position } = flowState.nodes[nodeId];
 	const selected = !!selection.nodes[nodeId];
 
-	const { x: left, y: top } =
-		selected && (graph.moveVector.x !== 0 || graph.moveVector.y !== 0)
-			? position.add(graph.moveVector)
-			: position;
+	const { x: left, y: top } = position;
 	return { selected, left, top, type, width };
 };
 

--- a/src/flow/flowAreaActions.ts
+++ b/src/flow/flowAreaActions.ts
@@ -1,6 +1,11 @@
 import { createAction } from "typesafe-actions";
+import { FlowAreaState } from "~/flow/state/flowAreaReducer";
 
 export const flowAreaActions = {
+	setFields: createAction("flowArea/SET_FIELDS", (action) => {
+		return (fields: Partial<FlowAreaState>) => action({ fields });
+	}),
+
 	setGraphId: createAction("flowArea/SET_GRAPH_ID", (action) => {
 		return (graphId: string) => action({ graphId });
 	}),

--- a/src/flow/flowComputeNode.ts
+++ b/src/flow/flowComputeNode.ts
@@ -206,63 +206,6 @@ const computeFnMap: Record<Type, (args: FlowComputeNodeArg[]) => FlowComputeNode
 
 	[Type.expr]: () => {
 		throw new Error("Not implemented");
-		// if (!ctx.expressionCache[node.id]) {
-		// 	ctx.expressionCache[node.id] = mathjs.compile(state.expression);
-		// }
-
-		// const expression = ctx.expressionCache[node.id];
-
-		// const scope = {
-		// 	...node.outputs.reduce<{ [key: string]: any }>((obj, output) => {
-		// 		obj[output.name] = null;
-		// 		return obj;
-		// 	}, {}),
-		// 	...node.inputs.reduce<{ [key: string]: any }>((obj, input, i) => {
-		// 		obj[input.name] = args[i].value;
-		// 		return obj;
-		// 	}, {}),
-		// };
-
-		// expression.evaluate(scope);
-
-		// const resolve = (res: any): FlowComputeNodeArg => {
-		// 	switch (mathjs.typeOf(res)) {
-		// 		case "Matrix": {
-		// 			const data = res._data as any[];
-		// 			for (let i = 0; i < data.length; i++) {
-		// 				if (mathjs.typeOf(data[i]) !== "number") {
-		// 					throw new Error("Matrices may only contain numbers.");
-		// 				}
-		// 			}
-		// 			return flowNodeArg.any(data);
-		// 		}
-
-		// 		case "number": {
-		// 			return flowNodeArg.number(res);
-		// 		}
-
-		// 		case "boolean": {
-		// 			return flowNodeArg.any(res);
-		// 		}
-
-		// 		case "string": {
-		// 			return flowNodeArg.any(res);
-		// 		}
-
-		// 		case "Object": {
-		// 			return flowNodeArg.any(res);
-		// 		}
-
-		// 		default:
-		// 			throw new Error(`Unknown type '${mathjs.typeOf(res)}'`);
-		// 	}
-		// };
-
-		// const outputs = node.outputs.map((output) => {
-		// 	return resolve(scope[output.name]);
-		// });
-
-		// return outputs;
 	},
 
 	[Type.composition]: (args) => args,

--- a/src/flow/flowIO.ts
+++ b/src/flow/flowIO.ts
@@ -374,18 +374,3 @@ export const getFlowNodeDefaultOutputs = (type: FlowNodeType): FlowNodeOutput[] 
 			return [];
 	}
 };
-
-export const flowValidInputsToOutputsMap: { [key in ValueType]: ValueType[] } = {
-	[ValueType.Any]: [ValueType.Any, ValueType.Number, ValueType.Rect, ValueType.Vec2],
-	[ValueType.Number]: [ValueType.Any, ValueType.Number, ValueType.Vec2],
-	[ValueType.Rect]: [ValueType.Any, ValueType.Rect],
-	[ValueType.Vec2]: [ValueType.Any, ValueType.Vec2],
-	[ValueType.RGBAColor]: [ValueType.Any, ValueType.RGBAColor, ValueType.RGBColor],
-	[ValueType.RGBColor]: [ValueType.Any, ValueType.RGBColor, ValueType.RGBAColor],
-	[ValueType.TransformBehavior]: [ValueType.TransformBehavior],
-	[ValueType.OriginBehavior]: [ValueType.OriginBehavior],
-	[ValueType.LineCap]: [ValueType.LineCap],
-	[ValueType.LineJoin]: [ValueType.LineJoin],
-	[ValueType.FillRule]: [ValueType.FillRule],
-	[ValueType.Path]: [ValueType.Path],
-};

--- a/src/flow/flowOperations.ts
+++ b/src/flow/flowOperations.ts
@@ -49,8 +49,30 @@ const removeGraph = (op: Operation, graphId: string): void => {
 	op.add(flowSelectionActions.removeGraph(graphId));
 };
 
+const connectOutputToInput = (
+	op: Operation,
+	outputNodeId: string,
+	outputIndex: number,
+	inputNodeId: string,
+	inputIndex: number,
+): void => {
+	op.add(flowActions.connectInputToOutput(outputNodeId, outputIndex, inputNodeId, inputIndex));
+	op.addDiff((diff) => diff.updateNodeConnection([outputNodeId, inputNodeId]));
+};
+
+const removeInputPointer = (op: Operation, inputNodeId: string, inputIndex: number): void => {
+	const { flowState } = op.state;
+	const node = flowState.nodes[inputNodeId];
+	const { nodeId: outputNodeId } = node.inputs[inputIndex].pointer!;
+
+	op.add(flowActions.removeInputPointer(inputNodeId, inputIndex));
+	op.addDiff((diff) => diff.updateNodeConnection([outputNodeId, inputNodeId]));
+};
+
 export const flowOperations = {
 	selectNode,
 	removeSelectedNodesInGraph,
 	removeGraph,
+	connectOutputToInput,
+	removeInputPointer,
 };

--- a/src/flow/flowTypes.ts
+++ b/src/flow/flowTypes.ts
@@ -49,26 +49,9 @@ export interface FlowGraph {
 	layerId: string;
 	propertyId: string;
 	id: string;
-	moveVector: Vec2;
 	nodes: string[];
 	_addNodeOfTypeOnClick: { type: FlowNodeType; io?: FlowNodeIO } | null;
 	_dragSelectRect: Rect | null;
-	_dragOutputTo: {
-		position: Vec2;
-		fromOutput: { nodeId: string; outputIndex: number };
-		wouldConnectToInput: {
-			nodeId: string;
-			inputIndex: number;
-		} | null;
-	} | null;
-	_dragInputTo: {
-		position: Vec2;
-		fromInput: { nodeId: string; inputIndex: number };
-		wouldConnectToOutput: {
-			nodeId: string;
-			outputIndex: number;
-		} | null;
-	} | null;
 }
 
 export interface FlowNode<T extends FlowNodeType = FlowNodeType> {

--- a/src/flow/flowValueConversion.ts
+++ b/src/flow/flowValueConversion.ts
@@ -1,0 +1,201 @@
+import {
+	FillRule,
+	LineCap,
+	LineJoin,
+	OriginBehavior,
+	RGBAColor,
+	RGBColor,
+	TransformBehavior,
+	ValueType,
+} from "~/types";
+import { capToRange } from "~/util/math";
+
+const toNumber: Partial<Record<ValueType, (value: unknown) => number | undefined>> = {
+	[ValueType.Any]: (value) => {
+		if (typeof value === "number") {
+			return value;
+		}
+		const val = Number(value);
+		if (!isNaN(val)) {
+			return val;
+		}
+		return undefined;
+	},
+};
+
+const isObjectWithXY = (value: object): value is { x: any; y: any } => {
+	if ("x" in value && "y" in value) {
+		return true;
+	}
+	return false;
+};
+
+const toVec2: Partial<Record<ValueType, (value: unknown) => Vec2 | undefined>> = {
+	[ValueType.Any]: (value) => {
+		const v = value;
+		if (v instanceof Vec2) {
+			return v;
+		}
+		if (typeof v !== "object" || !v) {
+			return undefined;
+		}
+
+		let x: number | undefined;
+		let y: number | undefined;
+
+		if (Array.isArray(v)) {
+			x = typeof v[0] === "number" ? v[0] : parseFloat(v[0]);
+			y = typeof v[1] === "number" ? v[1] : parseFloat(v[1]);
+		} else if (isObjectWithXY(v)) {
+			x = typeof v.x === "number" ? v.x : parseFloat(v.x);
+			y = typeof v.y === "number" ? v.y : parseFloat(v.y);
+		}
+
+		if (typeof x === "undefined" || typeof y === "undefined" || isNaN(x) || isNaN(y)) {
+			return undefined;
+		}
+
+		return Vec2.new(x, y);
+	},
+	[ValueType.Number]: (value) => Vec2.new(value as number, value as number),
+};
+
+const isObjectWithRectProperties = (
+	value: object,
+): value is { left: any; top: any; width: any; height: any } => {
+	if ("left" in value && "top" in value && "width" in value && "height" in value) {
+		return true;
+	}
+	return false;
+};
+
+const toRect: Partial<Record<ValueType, (value: unknown) => Rect | undefined>> = {
+	[ValueType.Any]: (value) => {
+		const v = value;
+
+		if (typeof v !== "object" || !v || !isObjectWithRectProperties(v)) {
+			return undefined;
+		}
+
+		let left: number;
+		let top: number;
+		let width: number;
+		let height: number;
+
+		left = typeof v.left === "number" ? v.left : parseFloat(v.left);
+		top = typeof v.top === "number" ? v.top : parseFloat(v.top);
+		width = typeof v.width === "number" ? v.width : parseFloat(v.width);
+		height = typeof v.height === "number" ? v.height : parseFloat(v.height);
+
+		if (isNaN(left) || isNaN(top) || isNaN(width) || isNaN(height)) {
+			return undefined;
+		}
+
+		return { left, top, width, height };
+	},
+};
+
+const toRgbaColor: Partial<Record<ValueType, (value: unknown) => RGBAColor | undefined>> = {
+	[ValueType.Any]: (value) => {
+		if (Array.isArray(value)) {
+			const [r, g, b, a] = value.map((n) => capToRange(0, 255, parseInt(n)));
+			const color: RGBAColor = [r, g, b, a];
+
+			for (let i = 0; i < color.length; i += 1) {
+				if (isNaN(color[i])) {
+					return undefined;
+				}
+			}
+
+			return color;
+		}
+
+		return undefined;
+	},
+};
+
+type ValueTypeToValue = {
+	[ValueType.Any]: any;
+	[ValueType.Number]: number;
+	[ValueType.Vec2]: Vec2;
+	[ValueType.Rect]: Rect;
+	[ValueType.RGBAColor]: RGBAColor;
+	[ValueType.FillRule]: FillRule;
+	[ValueType.LineCap]: LineCap;
+	[ValueType.LineJoin]: LineJoin;
+	[ValueType.OriginBehavior]: OriginBehavior;
+	[ValueType.Path]: string;
+	[ValueType.TransformBehavior]: TransformBehavior;
+	[ValueType.RGBColor]: RGBColor;
+};
+
+const valueTypeToConverter: {
+	[T in ValueType]?: Partial<Record<ValueType, (value: unknown) => unknown | undefined>>;
+} = {
+	[ValueType.Number]: toNumber,
+	[ValueType.Vec2]: toVec2,
+	[ValueType.Rect]: toRect,
+	[ValueType.RGBAColor]: toRgbaColor,
+};
+
+export const parseTypedValue = <
+	To extends ValueType,
+	T extends ValueTypeToValue[To] = ValueTypeToValue[To]
+>(
+	from: ValueType,
+	to: To,
+	value: unknown,
+): T | undefined => {
+	if (from === to) {
+		return value as T;
+	}
+
+	if (to === ValueType.Any) {
+		return value as T;
+	}
+
+	const converter = valueTypeToConverter[from]?.[to];
+	if (converter) {
+		return converter(value) as T;
+	}
+	return undefined;
+};
+
+const valueTypes = Object.values(ValueType);
+
+const valueTypesThatCanConvertToMap = valueTypes.reduce<Record<ValueType, Set<ValueType>>>(
+	(obj, valueType) => {
+		const set = new Set<ValueType>([valueType, ValueType.Any]);
+		const converters = valueTypeToConverter[valueType] || {};
+		const keys = Object.keys(converters) as ValueType[];
+		keys.forEach((key) => set.add(key));
+		obj[valueType] = set;
+		return obj;
+	},
+	{} as any,
+);
+
+const canConvertToValueTypesMap = valueTypes.reduce<Record<ValueType, Set<ValueType>>>(
+	(obj, valueType) => {
+		const set = new Set<ValueType>([valueType, ValueType.Any]);
+
+		for (const vt of valueTypes) {
+			const canConvertTo = valueTypesThatCanConvertToMap[vt];
+			if (canConvertTo.has(valueType)) {
+				set.add(vt);
+			}
+		}
+
+		obj[valueType] = set;
+		return obj;
+	},
+	{} as any,
+);
+
+export const getValueTypeCanConvertToValueTypes = (valueType: ValueType): Set<ValueType> => {
+	return canConvertToValueTypesMap[valueType];
+};
+
+export const getValueTypesThatCanConvertToValueType = (valueType: ValueType): Set<ValueType> => {
+	return canConvertToValueTypesMap[valueType];
+};

--- a/src/flow/inputs/NodeTValueInput.tsx
+++ b/src/flow/inputs/NodeTValueInput.tsx
@@ -27,9 +27,11 @@ const NodeTValueInputComponent: React.FC<Props> = (props) => {
 
 	const { onChange, onChangeEnd } = useNumberInputAction({
 		onChange: (value, params) => {
+			params.performDiff((diff) => diff.flowNodeState(nodeId));
 			params.dispatch(flowActions.setNodeInputValue(graphId, nodeId, index, value));
 		},
 		onChangeEnd: (_type, params) => {
+			params.addDiff((diff) => diff.flowNodeState(nodeId));
 			params.submitAction("Update input value");
 		},
 	});

--- a/src/flow/state/flowActions.ts
+++ b/src/flow/state/flowActions.ts
@@ -64,6 +64,15 @@ export const flowActions = {
 		return (graphId: string) => action({ graphId });
 	}),
 
+	connectInputToOutput: createAction("flowGraph/CONNECT_INPUT_TO_OUTPUT", (action) => {
+		return (
+			outputNodeId: string,
+			outputIndex: number,
+			inputNodeId: string,
+			inputIndex: number,
+		) => action({ outputNodeId, outputIndex, inputNodeId, inputIndex });
+	}),
+
 	clearDragOutputTo: createAction("flowGraph/CLEAR_DRAG_OUTPUT_TO", (action) => {
 		return (graphId: string) => action({ graphId });
 	}),
@@ -95,8 +104,7 @@ export const flowActions = {
 	 * Pointer
 	 */
 	removeInputPointer: createAction("flowGraph/REMOVE_INPUT_POINTER", (action) => {
-		return (graphId: string, nodeId: string, inputIndex: number) =>
-			action({ graphId, nodeId, inputIndex });
+		return (nodeId: string, inputIndex: number) => action({ nodeId, inputIndex });
 	}),
 
 	/**

--- a/src/flow/state/flowActions.ts
+++ b/src/flow/state/flowActions.ts
@@ -28,6 +28,9 @@ export const flowActions = {
 	setNode: createAction("flowGraph/SET_NODE", (action) => {
 		return (node: FlowNode) => action({ node });
 	}),
+	setNodePosition: createAction("flowGraph/SET_NODE_POSITION", (action) => {
+		return (nodeId: string, position: Vec2) => action({ nodeId, position });
+	}),
 
 	/**
 	 * Add node

--- a/src/flow/state/flowActions.ts
+++ b/src/flow/state/flowActions.ts
@@ -8,7 +8,6 @@ import {
 	FlowNodeOutput,
 	FlowNodeType,
 } from "~/flow/flowTypes";
-import { FlowGraphSelection } from "~/flow/state/flowSelectionReducer";
 
 export const flowActions = {
 	/**
@@ -44,29 +43,6 @@ export const flowActions = {
 		return (graphId: string, position: Vec2) => action({ graphId, position });
 	}),
 
-	/**
-	 * Drag output to
-	 */
-	initDragOutputTo: createAction("flowGraph/INIT_DRAG_OUTPUT_TO", (action) => {
-		return (
-			graphId: string,
-			position: Vec2,
-			fromOutput: { nodeId: string; outputIndex: number },
-		) => action({ graphId, position, fromOutput });
-	}),
-
-	setDragOutputTo: createAction("flowGraph/SET_DRAG_OUTPUT_TO", (action) => {
-		return (
-			graphId: string,
-			position: Vec2,
-			wouldConnectToInput: { nodeId: string; inputIndex: number } | null,
-		) => action({ graphId, position, wouldConnectToInput });
-	}),
-
-	submitDragOutputTo: createAction("flowGraph/SUBMIT_DRAG_OUTPUT_TO", (action) => {
-		return (graphId: string) => action({ graphId });
-	}),
-
 	connectInputToOutput: createAction("flowGraph/CONNECT_INPUT_TO_OUTPUT", (action) => {
 		return (
 			outputNodeId: string,
@@ -74,33 +50,6 @@ export const flowActions = {
 			inputNodeId: string,
 			inputIndex: number,
 		) => action({ outputNodeId, outputIndex, inputNodeId, inputIndex });
-	}),
-
-	clearDragOutputTo: createAction("flowGraph/CLEAR_DRAG_OUTPUT_TO", (action) => {
-		return (graphId: string) => action({ graphId });
-	}),
-
-	/**
-	 * Drag input to
-	 */
-	initDragInputTo: createAction("flowGraph/INIT_DRAG_INPUT_TO", (action) => {
-		return (
-			graphId: string,
-			position: Vec2,
-			fromInput: { nodeId: string; inputIndex: number },
-		) => action({ graphId, position, fromInput });
-	}),
-
-	setDragInputTo: createAction("flowGraph/SET_DRAG_INPUT_TO", (action) => {
-		return (
-			graphId: string,
-			position: Vec2,
-			wouldConnectToOutput: { nodeId: string; outputIndex: number } | null,
-		) => action({ graphId, position, wouldConnectToOutput });
-	}),
-
-	submitDragInputTo: createAction("flowGraph/SUBMIT_DRAG_INPUT_TO", (action) => {
-		return (graphId: string) => action({ graphId });
 	}),
 
 	/**
@@ -120,17 +69,6 @@ export const flowActions = {
 	submitDragSelectRect: createAction("flowGraph/SUBMIT_DRAG_SELECT", (action) => {
 		return (graphId: string, additiveSelection: boolean) =>
 			action({ graphId, additiveSelection });
-	}),
-
-	/**
-	 * Move node
-	 */
-	setMoveVector: createAction("flowGraph/SET_MOVE_VECTOR", (action) => {
-		return (graphId: string, moveVector: Vec2) => action({ graphId, moveVector });
-	}),
-
-	applyMoveVector: createAction("flowGraph/APPLY_MOVE_VECTOR", (action) => {
-		return (graphId: string, selection: FlowGraphSelection) => action({ graphId, selection });
 	}),
 
 	/**

--- a/src/flow/state/flowAreaReducer.ts
+++ b/src/flow/state/flowAreaReducer.ts
@@ -1,25 +1,29 @@
 import { ActionType, getType } from "typesafe-actions";
 import { flowAreaActions } from "~/flow/flowAreaActions";
 
-type ToolAction = ActionType<typeof flowAreaActions>;
+type Action = ActionType<typeof flowAreaActions>;
 
 export interface FlowAreaState {
 	pan: Vec2;
 	scale: number;
 	graphId: string;
+	dragPreview: [Vec2, Vec2] | null;
 }
 
 export const initialFlowAreaState: FlowAreaState = {
 	pan: Vec2.new(0, 0),
 	scale: 1,
 	graphId: "",
+	dragPreview: null,
 };
 
-export const flowAreaReducer = (
-	state = initialFlowAreaState,
-	action: ToolAction,
-): FlowAreaState => {
+export const flowAreaReducer = (state = initialFlowAreaState, action: Action): FlowAreaState => {
 	switch (action.type) {
+		case getType(flowAreaActions.setFields): {
+			const { fields } = action.payload;
+			return { ...state, ...fields };
+		}
+
 		case getType(flowAreaActions.setGraphId): {
 			const { graphId } = action.payload;
 			return { ...state, graphId };

--- a/src/flow/state/flowReducers.ts
+++ b/src/flow/state/flowReducers.ts
@@ -40,6 +40,11 @@ export function flowReducer(state: FlowState, action: FlowAction): FlowState {
 			return { ...state, nodes: { ...state.nodes, [node.id]: node } };
 		}
 
+		case getType(actions.setNodePosition): {
+			const { nodeId, position } = action.payload;
+			return { ...state, nodes: mergeItemInMap(state.nodes, nodeId, () => ({ position })) };
+		}
+
 		case getType(actions.removeGraph): {
 			const { graphId } = action.payload;
 			return {

--- a/src/flow/state/flowReducers.ts
+++ b/src/flow/state/flowReducers.ts
@@ -176,6 +176,21 @@ export function flowReducer(state: FlowState, action: FlowAction): FlowState {
 			};
 		}
 
+		case getType(actions.connectInputToOutput): {
+			const { outputNodeId, outputIndex, inputNodeId, inputIndex } = action.payload;
+
+			return {
+				...state,
+				nodes: mergeItemInMap(state.nodes, inputNodeId, (node) => ({
+					inputs: node.inputs.map<FlowNodeInput>((input, i) =>
+						i === inputIndex
+							? { ...input, pointer: { nodeId: outputNodeId, outputIndex } }
+							: input,
+					),
+				})),
+			};
+		}
+
 		case getType(actions.submitDragOutputTo): {
 			const { graphId } = action.payload;
 			const graph = state.graphs[graphId];

--- a/src/flow/state/flowReducers.ts
+++ b/src/flow/state/flowReducers.ts
@@ -53,33 +53,6 @@ export function flowReducer(state: FlowState, action: FlowAction): FlowState {
 			};
 		}
 
-		case getType(actions.setMoveVector): {
-			const { graphId, moveVector } = action.payload;
-			return {
-				...state,
-				graphs: modifyItemsInMap(state.graphs, graphId, (graph) => ({
-					...graph,
-					moveVector,
-				})),
-			};
-		}
-
-		case getType(actions.applyMoveVector): {
-			const { selection, graphId } = action.payload;
-			const { moveVector } = state.graphs[graphId];
-			return {
-				...state,
-				graphs: modifyItemsInMap(state.graphs, graphId, (graph) => ({
-					...graph,
-					moveVector: Vec2.new(0, 0),
-				})),
-				nodes: modifyItemsInMap(state.nodes, Object.keys(selection.nodes), (node) => ({
-					...node,
-					position: node.position.add(moveVector),
-				})),
-			};
-		}
-
 		case getType(actions.removeNode): {
 			const { nodeId } = action.payload;
 			return removeFlowNodeAndReferencesToIt(nodeId, state);
@@ -156,31 +129,6 @@ export function flowReducer(state: FlowState, action: FlowAction): FlowState {
 			};
 		}
 
-		case getType(actions.initDragOutputTo): {
-			const { graphId, position, fromOutput } = action.payload;
-			return {
-				...state,
-				graphs: mergeItemInMap(state.graphs, graphId, () => ({
-					_dragOutputTo: { position, fromOutput, wouldConnectToInput: null },
-				})),
-			};
-		}
-
-		case getType(actions.setDragOutputTo): {
-			const { graphId, position, wouldConnectToInput } = action.payload;
-
-			if (!state.graphs[graphId]._dragOutputTo) {
-				return state;
-			}
-
-			return {
-				...state,
-				graphs: mergeItemInMap(state.graphs, graphId, (graph) => ({
-					_dragOutputTo: { ...graph._dragOutputTo!, position, wouldConnectToInput },
-				})),
-			};
-		}
-
 		case getType(actions.connectInputToOutput): {
 			const { outputNodeId, outputIndex, inputNodeId, inputIndex } = action.payload;
 
@@ -193,88 +141,6 @@ export function flowReducer(state: FlowState, action: FlowAction): FlowState {
 							: input,
 					),
 				})),
-			};
-		}
-
-		case getType(actions.submitDragOutputTo): {
-			const { graphId } = action.payload;
-			const graph = state.graphs[graphId];
-
-			if (!graph._dragOutputTo?.wouldConnectToInput) {
-				return state;
-			}
-
-			const { outputIndex, nodeId: outputNodeId } = graph._dragOutputTo.fromOutput;
-			const { inputIndex, nodeId: inputNodeId } = graph._dragOutputTo.wouldConnectToInput;
-
-			return {
-				...state,
-				nodes: mergeItemInMap(state.nodes, inputNodeId, (node) => ({
-					inputs: node.inputs.map<FlowNodeInput>((input, i) =>
-						i === inputIndex
-							? { ...input, pointer: { nodeId: outputNodeId, outputIndex } }
-							: input,
-					),
-				})),
-				graphs: mergeItemInMap(state.graphs, graphId, () => ({ _dragOutputTo: null })),
-			};
-		}
-
-		case getType(actions.initDragInputTo): {
-			const { graphId, position, fromInput } = action.payload;
-			return {
-				...state,
-				graphs: mergeItemInMap(state.graphs, graphId, () => ({
-					_dragInputTo: { position, fromInput, wouldConnectToOutput: null },
-				})),
-			};
-		}
-
-		case getType(actions.setDragInputTo): {
-			const { graphId, position, wouldConnectToOutput } = action.payload;
-
-			const graph = state.graphs[graphId];
-			if (!graph._dragInputTo) {
-				return state;
-			}
-
-			return {
-				...state,
-				graphs: mergeItemInMap(state.graphs, graphId, () => ({
-					_dragInputTo: { ...graph._dragInputTo!, position, wouldConnectToOutput },
-				})),
-			};
-		}
-
-		case getType(actions.submitDragInputTo): {
-			const { graphId } = action.payload;
-			const graph = state.graphs[graphId];
-
-			if (!graph._dragInputTo?.wouldConnectToOutput) {
-				return state;
-			}
-
-			const { inputIndex, nodeId: inputNodeId } = graph._dragInputTo.fromInput;
-			const { outputIndex, nodeId: outputNodeId } = graph._dragInputTo.wouldConnectToOutput;
-
-			return {
-				...state,
-				nodes: mergeItemInMap(state.nodes, inputNodeId, (node) => ({
-					inputs: node.inputs.map<FlowNodeInput>((input, i) =>
-						i === inputIndex
-							? { ...input, pointer: { nodeId: outputNodeId, outputIndex } }
-							: input,
-					),
-				})),
-				graphs: mergeItemInMap(state.graphs, graphId, () => ({ _dragInputTo: null })),
-			};
-		}
-
-		case getType(actions.clearDragOutputTo): {
-			const { graphId } = action.payload;
-			return {
-				...state,
-				graphs: mergeItemInMap(state.graphs, graphId, () => ({ _dragOutputTo: null })),
 			};
 		}
 

--- a/src/flow/util/flowNodeAvailableIO.ts
+++ b/src/flow/util/flowNodeAvailableIO.ts
@@ -1,0 +1,137 @@
+import {
+	getValueTypeCanConvertToValueTypes,
+	getValueTypesThatCanConvertToValueType,
+} from "~/flow/flowValueConversion";
+import { FlowState } from "~/flow/state/flowReducers";
+
+interface AvailableInput {
+	inputNodeId: string;
+	inputIndex: number;
+}
+interface AvailableOutput {
+	outputNodeId: string;
+	outputIndex: number;
+}
+
+function findNodesThatNodeReferences(flowState: FlowState, nodeId: string): Set<string> {
+	const visited = new Set<string>();
+
+	function dfs(nodeId: string) {
+		if (visited.has(nodeId)) {
+			return;
+		}
+		visited.add(nodeId);
+
+		const node = flowState.nodes[nodeId];
+		for (const input of node.inputs) {
+			if (!input.pointer) {
+				continue;
+			}
+			dfs(input.pointer.nodeId);
+		}
+	}
+	dfs(nodeId);
+
+	return visited;
+}
+
+function findNodesThatReferenceNode(flowState: FlowState, nodeId: string): Set<string> {
+	const visited = new Set<string>();
+
+	const nodeToNext: Record<string, Set<string>> = {};
+
+	const graph = flowState.graphs[flowState.nodes[nodeId].graphId];
+	for (const nodeId of graph.nodes) {
+		nodeToNext[nodeId] = new Set();
+	}
+
+	for (const nodeId of graph.nodes) {
+		const node = flowState.nodes[nodeId];
+		for (const input of node.inputs) {
+			if (!input.pointer) {
+				continue;
+			}
+
+			nodeToNext[input.pointer.nodeId].add(nodeId);
+		}
+	}
+
+	function dfs(nodeId: string) {
+		if (visited.has(nodeId)) {
+			return;
+		}
+		visited.add(nodeId);
+
+		for (const id of [...nodeToNext[nodeId]]) {
+			dfs(id);
+		}
+	}
+	dfs(nodeId);
+
+	return visited;
+}
+
+export const getFlowGraphAvailableInputs = (
+	flowState: FlowState,
+	graphId: string,
+	nodeId: string,
+	outputIndex: number,
+): AvailableInput[] => {
+	const availableInputs: AvailableInput[] = [];
+
+	const graph = flowState.graphs[graphId];
+	const node = flowState.nodes[nodeId];
+	const valueType = node.outputs[outputIndex].type;
+
+	const canConvertToTypes = getValueTypeCanConvertToValueTypes(valueType);
+
+	const disallowedNodeIds = findNodesThatNodeReferences(flowState, nodeId);
+
+	for (const nodeId of graph.nodes) {
+		if (disallowedNodeIds.has(nodeId)) {
+			continue;
+		}
+
+		for (const [inputIndex, input] of flowState.nodes[nodeId].inputs.entries()) {
+			if (!canConvertToTypes.has(input.type)) {
+				continue;
+			}
+
+			availableInputs.push({ inputNodeId: nodeId, inputIndex });
+		}
+	}
+
+	return availableInputs;
+};
+
+export const getFlowGraphAvailableOutputs = (
+	flowState: FlowState,
+	graphId: string,
+	nodeId: string,
+	inputIndex: number,
+): AvailableOutput[] => {
+	const availableOutputs: AvailableOutput[] = [];
+
+	const graph = flowState.graphs[graphId];
+	const node = flowState.nodes[nodeId];
+	const valueType = node.inputs[inputIndex].type;
+	const typesThatCanConvertToType = getValueTypesThatCanConvertToValueType(valueType);
+
+	const disallowedNodeIds = findNodesThatReferenceNode(flowState, nodeId);
+
+	for (const nodeId of graph.nodes) {
+		if (disallowedNodeIds.has(nodeId)) {
+			continue;
+		}
+
+		for (const [outputIndex, output] of flowState.nodes[nodeId].outputs.entries()) {
+			if (!typesThatCanConvertToType.has(output.type)) {
+				continue;
+			}
+
+			availableOutputs.push({ outputNodeId: nodeId, outputIndex });
+		}
+	}
+
+	return availableOutputs;
+};

--- a/src/listener/requestAction.ts
+++ b/src/listener/requestAction.ts
@@ -21,6 +21,7 @@ interface RequestActionOptions {
 
 interface SubmitOptions {
 	allowIndexShift: boolean;
+	shouldAddToStack?: ShouldAddToStackFn;
 }
 
 export interface RequestActionParams {
@@ -128,7 +129,9 @@ const performRequestedAction = (
 			dispatch(areaActions.dispatchToAreaState(areaId, action));
 		},
 
-		submitAction: (name = "Unknown action", { allowIndexShift = false } = {}) => {
+		submitAction: (name = "Unknown action", options = {}) => {
+			const { allowIndexShift = false } = options;
+
 			if (!getActionId()) {
 				console.warn("Attempted to submit an action that does not exist.");
 				return;
@@ -147,7 +150,11 @@ const performRequestedAction = (
 				shouldAddToStackFns.push(shouldAddToStack);
 			}
 
-			let addToStack = typeof shouldAddToStack === "undefined";
+			if (options.shouldAddToStack) {
+				shouldAddToStackFns.push(options.shouldAddToStack);
+			}
+
+			let addToStack = shouldAddToStackFns.length === 0;
 
 			for (const shouldAddToStack of shouldAddToStackFns) {
 				if (shouldAddToStack(getCurrentState(), getActionState())) {


### PR DESCRIPTION
## Fix computation order for when Count changes in Array Modifier Graphs

The statement

```tsx
propertyIdToAffectedInputNodes[countId] = [...graph.nodes];
```

Computes the graph nodes in the order they were added to the graph. In this graph

```
1 <- 2 <- 0
```

0 would be computed before 2 which results in 0 reading the previous computed value of 2.

Replaced with:

```tsx
const toComputeStartIndex = toCompute.length;
onGraphId(group.graphId); // Updates toCompute

// ...

propertyIdToAffectedInputNodes[countId] = toCompute.slice(toComputeStartIndex);
```


## Refactor `nodeHandlers`

The handlers now use `mouseDownMoveAction` and `flowOperations` among other more modern patterns.


## Remove `_dragOutputTo`, `_dragInputTo` and `moveVector`

These fields were causing more complex and more verbose. The first two were replaced with `dragPreview` in `FlowAreaState` and the `moveVector` was removed entirely.


## Disallow circular references within graph

Created `flowNodeAvailableIO` which exports:

```
getFlowGraphAvailableInputs
getFlowGraphAvailableOutputs
```

which is used when dragging inputs to outputs.


## Prepare for "Invalid graph" behavior

See #90. Created `flowValueConversion` which contains conversion logic for different value types. It contains the following map:

```tsx
const valueTypeToConverter: {
	[T in ValueType]?: Partial<Record<ValueType, (value: unknown) => unknown | undefined>>;
} = {
	[ValueType.Number]: toNumber,
	[ValueType.Vec2]: toVec2,
	[ValueType.Rect]: toRect,
	[ValueType.RGBAColor]: toRgbaColor,
};
```

The `to{Value}` maps contain parsers from `ValueType.Any`:

```tsx
const toNumber: Partial<Record<ValueType, (value: unknown) => number | undefined>> = {
	[ValueType.Any]: (value) => {
		if (typeof value === "number") {
			return value;
		}
		const val = Number(value);
		if (!isNaN(val)) {
			return val;
		}
		return undefined;
	},
};
```

and converters from one value type to another:

```tsx
const toVec2: Partial<Record<ValueType, (value: unknown) => Vec2 | undefined>> = {
	[ValueType.Any]: (value) => {
		// ...
	},
	[ValueType.Number]: (value) => Vec2.new(value as number, value as number),
};
```

These are currently not used, but the map is used to determine:

 * Which value types can be converted to a value type
 * Which value types a certain value type can be converted to

via the exports:

```
getValueTypeCanConvertToValueTypes
getValueTypesThatCanConvertToValueType
```

which are used in

```
getFlowGraphAvailableInputs
getFlowGraphAvailableOutputs
```


## State diffs in `FlowNodeTValueInput`

The `flowNodeState` diff is now emitted on change.


## Add `shouldAddToStack` to `SubmitOptions`

Sometimes there are conditionals like so:

```tsx
if (hasMoved) {
	submitAction("Modify selection");
	return;
}

submitAction("Do thing");
```

These require different "should add to stack" behavior. One depends on the selection changing, and the other depends on something else.

Added `shouldAddToStack` to `SubmitOptions`

```tsx
interface SubmitOptions {
	// ...
	shouldAddToStack?: ShouldAddToStackFn;
}
```

so you can now do:

```tsx
if (hasMoved) {
	submitAction("Modify selection", { shouldAddToStack: didSelectionChange });
	return;
}

submitAction("Do thing");
```