### PR TITLE
Update Drag Area

### DIFF
--- a/src/area/areaOperations.ts
+++ b/src/area/areaOperations.ts
@@ -1,0 +1,68 @@
+import { areaActions } from "~/area/state/areaActions";
+import { computeAreaToParentRow } from "~/area/util/areaToParentRow";
+import { PlaceArea } from "~/area/util/areaUtils";
+import { Operation } from "~/types";
+import { Area, AreaRowLayout, AreaRowOrientation } from "~/types/areaTypes";
+
+function dragArea(op: Operation, area: Area, targetAreaId: string, placement: PlaceArea) {
+	op.add(areaActions.setFields({ areaToOpen: null }));
+
+	const areaState = op.state.area;
+
+	if (placement === "replace") {
+		op.add(areaActions.setAreaType(targetAreaId, area.type, area.state));
+		return;
+	}
+
+	let orientation: AreaRowOrientation;
+	let iOff: 0 | 1;
+
+	switch (placement) {
+		case "top":
+		case "left":
+			iOff = 0;
+			break;
+		case "bottom":
+		case "right":
+			iOff = 1;
+			break;
+	}
+
+	switch (placement) {
+		case "bottom":
+		case "top":
+			orientation = "vertical";
+			break;
+		case "left":
+		case "right":
+			orientation = "horizontal";
+			break;
+	}
+
+	const areaToParentRow = computeAreaToParentRow(areaState);
+
+	const parentRow = areaState.layout[areaToParentRow[targetAreaId]] as AreaRowLayout | undefined;
+
+	if (parentRow && parentRow.orientation === orientation) {
+		const targetIndex = parentRow.areas.map((x) => x.id).indexOf(targetAreaId);
+		const insertIndex = targetIndex + iOff;
+		op.add(areaActions.insertAreaIntoRow(parentRow.id, area, insertIndex));
+
+		const sizes = parentRow.areas.map((x) => x.size);
+		const size = sizes[targetIndex] / 2;
+		sizes.splice(targetIndex, 0, 1);
+		sizes[targetIndex] = size;
+		sizes[targetIndex + 1] = size;
+		op.add(areaActions.setRowSizes(parentRow.id, sizes));
+		return;
+	}
+
+	op.add(areaActions.wrapAreaInRow(targetAreaId, orientation));
+	const newRowId = (areaState._id + 1).toString();
+	op.add(areaActions.insertAreaIntoRow(newRowId, area, iOff));
+	op.add(areaActions.setRowSizes(newRowId, [1, 1]));
+}
+
+export const areaOperations = {
+	dragArea,
+};

--- a/src/area/components/AreaRoot.styles.ts
+++ b/src/area/components/AreaRoot.styles.ts
@@ -1,5 +1,6 @@
+import { cssVariables, cssZIndex } from "~/cssVariables";
+import { hexToRGBAString } from "~/util/color/convertColor";
 import { StyleParams } from "~/util/stylesheets";
-import { cssZIndex, cssVariables } from "~/cssVariables";
 
 export default ({ css, keyframes }: StyleParams) => {
 	const areaToOpenContainerAnimation = keyframes`
@@ -39,9 +40,21 @@ export default ({ css, keyframes }: StyleParams) => {
 		areaToOpenTargetOverlay: css`
 			z-index: ${cssZIndex.area.areaToOpenTarget};
 			position: absolute;
-			background: ${cssVariables.primary700};
+			background: ${hexToRGBAString(cssVariables.primary700, 0.07)};
 			border-radius: 8px;
-			opacity: 0.1;
+			opacity: 1;
+			overflow: hidden;
+		`,
+
+		placement: css`
+			line {
+				stroke-width: 1px;
+				stroke: ${hexToRGBAString(cssVariables.primary700, 0.3)};
+			}
+
+			path {
+				fill: ${hexToRGBAString(cssVariables.primary700, 0.15)};
+			}
 		`,
 	};
 };

--- a/src/area/components/AreaToOpenPreview.tsx
+++ b/src/area/components/AreaToOpenPreview.tsx
@@ -1,15 +1,112 @@
-import React from "react";
-import { connectActionState } from "~/state/stateUtils";
-import { contractRect } from "~/util/math";
-import { AreaReducerState } from "~/area/state/areaReducer";
-import { getAreaToOpenTargetId } from "~/area/util/areaUtils";
-import { useVec2TransitionState } from "~/hook/useNumberTransitionState";
-import { useEffect } from "react";
-import { AREA_BORDER_WIDTH } from "~/constants";
-import { AreaComponent } from "~/area/components/Area";
+import React, { useEffect, useMemo } from "react";
 import { areaComponentRegistry } from "~/area/areaRegistry";
-import { compileStylesheetLabelled } from "~/util/stylesheets";
+import { AreaComponent } from "~/area/components/Area";
 import AreaRootStyles from "~/area/components/AreaRoot.styles";
+import { AREA_PLACEMENT_TRESHOLD } from "~/area/state/areaConstants";
+import { AreaReducerState } from "~/area/state/areaReducer";
+import {
+	getAreaToOpenPlacementInViewport,
+	getHoveredAreaId,
+	PlaceArea,
+} from "~/area/util/areaUtils";
+import { AREA_BORDER_WIDTH } from "~/constants";
+import { useVec2TransitionState } from "~/hook/useNumberTransitionState";
+import { connectActionState } from "~/state/stateUtils";
+import { AreaToOpen } from "~/types/areaTypes";
+import { contractRect } from "~/util/math";
+import { compileStylesheetLabelled } from "~/util/stylesheets";
+
+interface RenderAreaToOpenProps {
+	viewport: Rect;
+	areaToOpen: AreaToOpen;
+	dimensions: Vec2;
+}
+
+const RenderAreaToOpen: React.FC<RenderAreaToOpenProps> = (props) => {
+	const { areaToOpen, viewport, dimensions } = props;
+
+	const placement = useMemo(() => {
+		return getAreaToOpenPlacementInViewport(viewport, areaToOpen.position);
+	}, [viewport, areaToOpen]);
+
+	const treshold = Math.min(viewport.width, viewport.height) * AREA_PLACEMENT_TRESHOLD;
+	const O = Vec2.new(treshold, treshold);
+
+	const w = viewport.width;
+	const h = viewport.height;
+
+	const nw_0 = Vec2.new(0, 0);
+	const nw_1 = nw_0.add(O);
+	const ne_0 = Vec2.new(w, 0);
+	const ne_1 = ne_0.add(O.scaleX(-1));
+	const sw_0 = Vec2.new(0, h);
+	const sw_1 = sw_0.add(O.scaleY(-1));
+	const se_0 = Vec2.new(w, h);
+	const se_1 = se_0.add(O.scale(-1));
+
+	const lines = [
+		[nw_0, nw_1],
+		[ne_0, ne_1],
+		[sw_0, sw_1],
+		[se_0, se_1],
+		[nw_1, ne_1],
+		[ne_1, se_1],
+		[se_1, sw_1],
+		[sw_1, nw_1],
+	];
+
+	const placementLines: Record<PlaceArea, Vec2[]> = {
+		left: [nw_0, nw_1, sw_1, sw_0],
+		top: [nw_0, ne_0, ne_1, nw_1],
+		right: [ne_1, ne_0, se_0, se_1],
+		bottom: [sw_0, sw_1, se_1, se_0],
+		replace: [nw_1, ne_1, se_1, sw_1],
+	};
+
+	const hlines = placementLines[placement];
+	const hd =
+		hlines
+			.map((p) => [p.x, p.y].join(","))
+			.map((str, i) => [i === 0 ? "M" : "L", str].join(" "))
+			.join(" ") + " Z";
+
+	return (
+		<>
+			<div
+				className={s("areaToOpenContainer")}
+				style={{
+					left: areaToOpen.position.x,
+					top: areaToOpen.position.y,
+				}}
+			>
+				<AreaComponent
+					id="-1"
+					Component={areaComponentRegistry[areaToOpen.area.type]}
+					raised
+					state={areaToOpen.area.state}
+					type={areaToOpen.area.type}
+					viewport={{
+						left: -(dimensions.x / 2),
+						top: -(dimensions.y / 2),
+						height: dimensions.y,
+						width: dimensions.x,
+					}}
+				/>
+			</div>
+			<div
+				className={s("areaToOpenTargetOverlay")}
+				style={contractRect(viewport, AREA_BORDER_WIDTH)}
+			>
+				<svg width={w} height={h} className={s("placement")}>
+					{lines.map(([p0, p1], i) => (
+						<line key={i} x1={p0.x} y1={p0.y} x2={p1.x} y2={p1.y} />
+					))}
+					<path d={hd} />
+				</svg>
+			</div>
+		</>
+	);
+};
 
 const s = compileStylesheetLabelled(AreaRootStyles);
 
@@ -26,7 +123,8 @@ const AreaToOpenPreviewComponent: React.FC<Props> = (props) => {
 	const { areaToOpen } = areaState;
 
 	const areaToOpenTargetId =
-		areaToOpen && getAreaToOpenTargetId(areaToOpen.position, areaState, props.areaToViewport);
+		areaToOpen && getHoveredAreaId(areaToOpen.position, areaState, props.areaToViewport);
+
 	const areaToOpenTargetViewport = areaToOpenTargetId && props.areaToViewport[areaToOpenTargetId];
 
 	const [areaToOpenDimensions, setAreaToOpenDimensions] = useVec2TransitionState(
@@ -49,33 +147,11 @@ const AreaToOpenPreviewComponent: React.FC<Props> = (props) => {
 	}
 
 	return (
-		<>
-			<div
-				className={s("areaToOpenContainer")}
-				style={{
-					left: areaToOpen.position.x,
-					top: areaToOpen.position.y,
-				}}
-			>
-				<AreaComponent
-					id="-1"
-					Component={areaComponentRegistry[areaToOpen.area.type]}
-					raised
-					state={areaToOpen.area.state}
-					type={areaToOpen.area.type}
-					viewport={{
-						left: -(areaToOpenDimensions.x / 2),
-						top: -(areaToOpenDimensions.y / 2),
-						height: areaToOpenDimensions.y,
-						width: areaToOpenDimensions.x,
-					}}
-				/>
-			</div>
-			<div
-				className={s("areaToOpenTargetOverlay")}
-				style={contractRect(areaToOpenTargetViewport, AREA_BORDER_WIDTH)}
-			/>
-		</>
+		<RenderAreaToOpen
+			areaToOpen={areaToOpen}
+			dimensions={areaToOpenDimensions}
+			viewport={areaToOpenTargetViewport}
+		/>
 	);
 };
 

--- a/src/area/handlers/areaDragFromCorner.ts
+++ b/src/area/handlers/areaDragFromCorner.ts
@@ -123,7 +123,9 @@ export const handleAreaDragFromCorner = (
 			const insertIndex =
 				areaIndex + (directionParts.indexOf(horizontal ? "w" : "n") !== -1 ? 0 : 1);
 
-			params.dispatch(areaActions.insertAreaIntoRow(row.id, areaId, insertIndex));
+			params.dispatch(
+				areaActions.insertAreaIntoRow(row.id, { ...areaState.areas[areaId] }, insertIndex),
+			);
 
 			// The size to share between the area and the new area is the size of the area
 			// before the action.

--- a/src/area/state/areaActions.ts
+++ b/src/area/state/areaActions.ts
@@ -1,8 +1,8 @@
 import { createAction } from "typesafe-actions";
-import { CardinalDirection } from "~/types";
-import { AreaType } from "~/constants";
 import { AreaReducerState } from "~/area/state/areaReducer";
-import { AreaState } from "~/types/areaTypes";
+import { AreaType } from "~/constants";
+import { CardinalDirection } from "~/types";
+import { Area, AreaRowOrientation, AreaState } from "~/types/areaTypes";
 
 export const areaActions = {
 	setFields: createAction("area/SET_FIELDS", (action) => {
@@ -20,8 +20,8 @@ export const areaActions = {
 	}),
 
 	insertAreaIntoRow: createAction("area/INSERT_AREA_INTO_ROW", (action) => {
-		return (rowId: string, basedOnId: string, insertIndex: number) =>
-			action({ rowId, basedOnId, insertIndex });
+		return (rowId: string, area: Area, insertIndex: number) =>
+			action({ rowId, area, insertIndex });
 	}),
 
 	convertAreaToRow: createAction("area/CONVERT_AREA_TO_ROW", (action) => {
@@ -34,6 +34,10 @@ export const areaActions = {
 
 	setRowSizes: createAction("area/SET_ROW_SIZES", (action) => {
 		return (rowId: string, sizes: number[]) => action({ rowId, sizes });
+	}),
+
+	wrapAreaInRow: createAction("area/WRAP_AREA_ROW", (action) => {
+		return (areaId: string, orientation: AreaRowOrientation) => action({ areaId, orientation });
 	}),
 
 	setAreaType: createAction("area/SET_TYPE", (action) => {

--- a/src/area/state/areaConstants.ts
+++ b/src/area/state/areaConstants.ts
@@ -1,0 +1,1 @@
+export const AREA_PLACEMENT_TRESHOLD = 0.25;

--- a/src/area/util/areaUtils.ts
+++ b/src/area/util/areaUtils.ts
@@ -1,7 +1,8 @@
+import { AREA_PLACEMENT_TRESHOLD } from "~/area/state/areaConstants";
 import { AreaReducerState } from "~/area/state/areaReducer";
 import { isVecInRect } from "~/util/math";
 
-export const getAreaToOpenTargetId = (
+export const getHoveredAreaId = (
 	position: Vec2,
 	areaState: AreaReducerState,
 	areaToViewport: {
@@ -24,4 +25,39 @@ export const getAreaToOpenTargetId = (
 	}
 
 	return areaId;
+};
+
+export type PlaceArea = "top" | "left" | "right" | "bottom" | "replace";
+
+export const getAreaToOpenPlacementInViewport = (rect: Rect, position: Vec2): PlaceArea => {
+	const w = rect.width;
+	const h = rect.height;
+
+	const x = position.x - rect.left;
+	const y = position.y - rect.top;
+
+	let placement: PlaceArea | undefined;
+	let dist = Infinity;
+
+	const treshold = Math.min(w, h) * AREA_PLACEMENT_TRESHOLD;
+
+	const tests: Array<{ placement: PlaceArea; dist: number }> = [
+		{ placement: "left", dist: x },
+		{ placement: "top", dist: y },
+		{ placement: "right", dist: w - x },
+		{ placement: "bottom", dist: h - y },
+	];
+
+	for (const test of tests) {
+		if (test.dist < treshold && test.dist < dist) {
+			dist = test.dist;
+			placement = test.placement;
+		}
+	}
+
+	if (!placement) {
+		return "replace";
+	}
+
+	return placement;
 };

--- a/src/area/util/dragOpenArea.ts
+++ b/src/area/util/dragOpenArea.ts
@@ -1,0 +1,64 @@
+import { areaOperations } from "~/area/areaOperations";
+import { areaActions } from "~/area/state/areaActions";
+import { computeAreaToViewport } from "~/area/util/areaToViewport";
+import { getAreaToOpenPlacementInViewport, getHoveredAreaId } from "~/area/util/areaUtils";
+import { getAreaRootViewport } from "~/area/util/getAreaViewport";
+import { RequestActionParams } from "~/listener/requestAction";
+import { performOperation } from "~/state/operation";
+import { getActionState } from "~/state/stateUtils";
+import { Area } from "~/types/areaTypes";
+import { mouseDownMoveAction } from "~/util/action/mouseDownMoveAction";
+
+interface Options {
+	area: Area;
+}
+
+export const dragOpenArea = (e: React.MouseEvent, options: Options) => {
+	const { area } = options;
+
+	let position: Vec2;
+
+	const onDone = (params: RequestActionParams) => {
+		const { area: areaState } = getActionState();
+		const rootViewport = getAreaRootViewport();
+		const areaToViewport = computeAreaToViewport(
+			areaState.layout,
+			areaState.rootId,
+			rootViewport,
+		);
+
+		let areaId = getHoveredAreaId(position, areaState, areaToViewport);
+
+		if (!areaId) {
+			params.cancelAction(); // Mouse is not over any area, cancel
+			return;
+		}
+
+		const viewport = areaToViewport[areaId];
+		const placement = getAreaToOpenPlacementInViewport(viewport, position);
+
+		performOperation(params, (op) => areaOperations.dragArea(op, area, areaId!, placement));
+		params.submitAction();
+	};
+
+	mouseDownMoveAction(e, {
+		keys: [],
+		beforeMove: (_params, { mousePosition }) => {
+			position = mousePosition.global;
+		},
+		mouseMove: (params, { mousePosition }) => {
+			position = mousePosition.global;
+			params.dispatch(areaActions.setFields({ areaToOpen: { area, position } }));
+		},
+		mouseUp: (params, didMove) => {
+			if (!didMove) {
+				params.dispatch(areaActions.setFields({ areaToOpen: { area, position } }));
+				return;
+			}
+			onDone(params);
+		},
+		mouseDown: (params) => {
+			onDone(params);
+		},
+	});
+};

--- a/src/project/composition/handlers/dragProjectTimelineToArea.ts
+++ b/src/project/composition/handlers/dragProjectTimelineToArea.ts
@@ -1,13 +1,7 @@
-import { areaActions } from "~/area/state/areaActions";
 import { areaInitialStates } from "~/area/state/areaInitialStates";
-import { computeAreaToViewport } from "~/area/util/areaToViewport";
-import { getAreaToOpenTargetId } from "~/area/util/areaUtils";
-import { getAreaRootViewport } from "~/area/util/getAreaViewport";
+import { dragOpenArea } from "~/area/util/dragOpenArea";
 import { AreaType } from "~/constants";
-import { requestAction } from "~/listener/requestAction";
-import { getActionState } from "~/state/stateUtils";
-import { TimelineAreaState } from "~/timeline/timelineAreaReducer";
-import { getDistance } from "~/util/math";
+import { Area } from "~/types/areaTypes";
 
 interface Options {
 	compositionId: string;
@@ -16,71 +10,10 @@ interface Options {
 export const dragProjectTimelineToArea = (e: React.MouseEvent, options: Options) => {
 	const { compositionId } = options;
 
-	const initialMousePos = Vec2.fromEvent(e);
+	const area: Area<AreaType.Timeline> = {
+		type: AreaType.Timeline,
+		state: { ...areaInitialStates[AreaType.Timeline], compositionId },
+	};
 
-	requestAction({ history: false }, (params) => {
-		const { dispatch, cancelAction, submitAction, addListener } = params;
-
-		const initialState: TimelineAreaState = {
-			...areaInitialStates[AreaType.Timeline],
-			compositionId,
-		};
-
-		let hasMoved = false;
-		let mousePos!: Vec2;
-
-		addListener.repeated("mousemove", (e) => {
-			mousePos = Vec2.fromEvent(e);
-
-			if (!hasMoved) {
-				if (getDistance(initialMousePos, mousePos) > 5) {
-					hasMoved = true;
-				} else {
-					return;
-				}
-			}
-
-			dispatch(
-				areaActions.setFields({
-					areaToOpen: {
-						position: mousePos,
-						area: {
-							type: AreaType.Timeline,
-							state: initialState,
-						},
-					},
-				}),
-			);
-		});
-
-		addListener.once("mouseup", () => {
-			if (!hasMoved) {
-				cancelAction();
-				return;
-			}
-
-			// Check whether the mouse is over an area other than the one we started at.
-
-			const areaState = getActionState().area;
-			const viewport = getAreaRootViewport();
-			const areaToViewport = computeAreaToViewport(
-				areaState.layout,
-				areaState.rootId,
-				viewport,
-			);
-
-			let areaId = getAreaToOpenTargetId(mousePos, areaState, areaToViewport);
-
-			if (!areaId) {
-				// Mouse is not over any area, cancel
-
-				cancelAction();
-				return;
-			}
-
-			dispatch(areaActions.setAreaType(areaId, AreaType.Timeline, initialState));
-			dispatch(areaActions.setFields({ areaToOpen: null }));
-			submitAction();
-		});
-	});
+	dragOpenArea(e, { area });
 };

--- a/src/project/composition/handlers/dragProjectWorkspaceToArea.tsx
+++ b/src/project/composition/handlers/dragProjectWorkspaceToArea.tsx
@@ -1,13 +1,7 @@
-import { areaActions } from "~/area/state/areaActions";
 import { areaInitialStates } from "~/area/state/areaInitialStates";
-import { computeAreaToViewport } from "~/area/util/areaToViewport";
-import { getAreaToOpenTargetId } from "~/area/util/areaUtils";
-import { getAreaRootViewport } from "~/area/util/getAreaViewport";
+import { dragOpenArea } from "~/area/util/dragOpenArea";
 import { AreaType } from "~/constants";
-import { requestAction } from "~/listener/requestAction";
-import { getActionState } from "~/state/stateUtils";
-import { getDistance } from "~/util/math";
-import { WorkspaceAreaState } from "~/workspace/workspaceAreaReducer";
+import { Area } from "~/types/areaTypes";
 
 interface Options {
 	compositionId: string;
@@ -16,71 +10,9 @@ interface Options {
 export const dragProjectWorkspaceToArea = (e: React.MouseEvent, options: Options) => {
 	const { compositionId } = options;
 
-	const initialMousePos = Vec2.fromEvent(e);
-
-	requestAction({ history: false }, (params) => {
-		const { dispatch, cancelAction, submitAction, addListener } = params;
-
-		const initialState: WorkspaceAreaState = {
-			...areaInitialStates[AreaType.Workspace],
-			compositionId,
-		};
-
-		let hasMoved = false;
-		let mousePos!: Vec2;
-
-		addListener.repeated("mousemove", (e) => {
-			mousePos = Vec2.fromEvent(e);
-
-			if (!hasMoved) {
-				if (getDistance(initialMousePos, mousePos) > 5) {
-					hasMoved = true;
-				} else {
-					return;
-				}
-			}
-
-			dispatch(
-				areaActions.setFields({
-					areaToOpen: {
-						position: mousePos,
-						area: {
-							type: AreaType.Workspace,
-							state: initialState,
-						},
-					},
-				}),
-			);
-		});
-
-		addListener.once("mouseup", () => {
-			if (!hasMoved) {
-				cancelAction();
-				return;
-			}
-
-			// Check whether the mouse is over an area other than the one we started at.
-
-			const areaState = getActionState().area;
-			const viewport = getAreaRootViewport();
-			const areaToViewport = computeAreaToViewport(
-				areaState.layout,
-				areaState.rootId,
-				viewport,
-			);
-
-			let areaId = getAreaToOpenTargetId(mousePos, areaState, areaToViewport);
-
-			if (!areaId) {
-				// Mouse is not over any area, cancel
-
-				cancelAction();
-				return;
-			}
-
-			dispatch(areaActions.setAreaType(areaId, AreaType.Workspace, initialState));
-			dispatch(areaActions.setFields({ areaToOpen: null }));
-			submitAction();
-		});
-	});
+	const area: Area<AreaType.Workspace> = {
+		type: AreaType.Workspace,
+		state: { ...areaInitialStates[AreaType.Workspace], compositionId },
+	};
+	dragOpenArea(e, { area });
 };

--- a/src/types/areaTypes.ts
+++ b/src/types/areaTypes.ts
@@ -3,6 +3,11 @@ import { FlowAreaState } from "~/flow/state/flowAreaReducer";
 import { TimelineAreaState } from "~/timeline/timelineAreaReducer";
 import { WorkspaceAreaState } from "~/workspace/workspaceAreaReducer";
 
+export interface AreaToOpen {
+	position: Vec2;
+	area: Area;
+}
+
 interface _AreaStates {
 	[AreaType.FlowEditor]: FlowAreaState;
 	[AreaType.Timeline]: TimelineAreaState;
@@ -23,10 +28,12 @@ export interface AreaLayout {
 	id: string;
 }
 
+export type AreaRowOrientation = "horizontal" | "vertical";
+
 export type AreaRowLayout = {
 	type: "area_row";
 	id: string;
-	orientation: "horizontal" | "vertical";
+	orientation: AreaRowOrientation;
 	areas: Array<{ size: number; id: string }>;
 };
 


### PR DESCRIPTION
When dragging to open an area, the target area is now split into groups.

![image](https://user-images.githubusercontent.com/20321920/125490384-5fc12dd2-1047-4670-af76-24b8d1884d1e.png)

By dropping the area in the center, the previous area is replaced. By dropping it on the edges, the area is split with the target being placed according to the target edge.

